### PR TITLE
Update to release version of SpeziFileFormats

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.4"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziFileFormats", branch: "fix/edf-access"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziFileFormats", from: "1.2.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4")


### PR DESCRIPTION
# Update to release version of SpeziFileFormats

## :recycle: Current situation & Problem
A previous PR #19 was accidentally merged by tagging a branch of the upcoming release of SpeziFileFormats. This PR fixes this issue and updates to the lates release accordingly.


## :gear: Release Notes 
* Fix version tag of SpeziFileFormats

## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
