### PR TITLE
Implement Blood Pressure Measurement characteristics and MedFloat16

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -28,7 +28,6 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/xcodebuild-or-fastlane.yml@v2
     with:
       runsonlabels: '["macOS", "self-hosted", "spezi"]'
-      setupSimulators: true
       path: 'Tests/UITests'
       scheme: TestApp
       artifactname: TestApp-iOS.xcresult

--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -51,3 +51,5 @@ jobs:
     uses: StanfordSpezi/.github/.github/workflows/create-and-upload-coverage-report.yml@v2
     with:
       coveragereports: SpeziBluetooth-Package.xcresult TestApp-iOS.xcresult TestApp-macOS.xcresult
+    secrets:
+      token: ${{ secrets.CODECOV_TOKEN }}

--- a/Sources/BluetoothServices/BluetoothServices.docc/BluetoothServices.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/BluetoothServices.md
@@ -1,6 +1,6 @@
 # ``BluetoothServices``
 
-Reusable Bluetooth Service implementations.
+Reusable Bluetooth Service and Characteristic implementations.
 
 <!--
 #
@@ -14,14 +14,16 @@ Reusable Bluetooth Service implementations.
 
 ## Overview
 
-This target provides reusable Bluetooth service implementations of standardized Bluetooth services.
+The `BluetoothServices` target provides several reusable components when developing Bluetooth peripherals
+with standardized services and characteristics.
 
 ## Topics
 
-### Core Services
+### Articles
 
-- ``DeviceInformationService``
+- <doc:Characteristics>
+- <doc:Services>
 
-### Health Domain
+### Data Types
 
-- ``HealthThermometerService``
+- ``MedFloat16``

--- a/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
@@ -1,0 +1,46 @@
+# Characteristics
+
+Reusable implementations of standardized Bluetooth Characteristics.
+
+<!--
+#
+# This source file is part of the Stanford Spezi open source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+-->
+
+## Overview
+
+SpeziBluetooth provides a collection of Bluetooth characteristics already out of the box.
+This includes generic characteristics like
+``DateTime`` and a collection of characteristics from the health domain.
+
+Below is a list of already implemented characteristics.
+Encoding and decoding is handled using [`ByteCodable`](https://swiftpackageindex.com/StanfordSpezi/SpeziFileFormats/documentation/bytecoding)
+which natively integrates with SpeziBluetooth-defined services.
+
+## Topics
+
+### Generic
+
+- ``DateTime``
+
+### Device Information
+
+- ``PnPID``
+- ``VendorIDSource``
+
+### Temperature Measurement
+
+- ``TemperatureMeasurement``
+- ``TemperatureType``
+- ``MeasurementInterval``
+
+### Blood Pressure
+
+- ``BloodPressureMeasurement``
+- ``BloodPressureFeature``
+- ``IntermediateCuffPressure``

--- a/Sources/BluetoothServices/BluetoothServices.docc/Services.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Services.md
@@ -1,0 +1,27 @@
+# Services
+
+Reusable implementations of standardized Bluetooth Services.
+
+<!--
+#
+# This source file is part of the Stanford Spezi open source project
+#
+# SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+#
+# SPDX-License-Identifier: MIT
+#
+-->
+
+## Overview
+
+Below is a list of reusable Bluetooth service implementations of standardized Bluetooth services.
+
+## Topics
+
+### Core Services
+
+- ``DeviceInformationService``
+
+### Health Domain
+
+- ``HealthThermometerService``

--- a/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
@@ -12,9 +12,6 @@ import NIOCore
 
 
 public struct BloodPressureFeature: OptionSet {
-    public var rawValue: UInt16
-
-
     /// Indicate if body movement detection is supported.
     ///
     /// If supported, use the ``BloodPressureMeasurement/Status/bodyMovementDetected`` field to indicate if
@@ -56,6 +53,7 @@ public struct BloodPressureFeature: OptionSet {
     /// Indicate if Device Time and User Facing Time reporting using Device Time Service (v1.0 or later).
     public static let userFacingTimeSupported = BloodPressureFeature(rawValue: 1 << 8)
 
+    public let rawValue: UInt16
 
     public init(rawValue: UInt16) {
         self.rawValue = rawValue

--- a/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
@@ -14,17 +14,48 @@ import NIOCore
 public struct BloodPressureFeature: OptionSet {
     public var rawValue: UInt16
 
-    // TODO: docs
 
+    /// Indicate if body movement detection is supported.
+    ///
+    /// If supported, use the ``BloodPressureMeasurement/Status/bodyMovementDetected`` field to indicate if
+    /// body movement was detected.
+    /// If not supported, the ``BloodPressureMeasurement/Status/bodyMovementDetected`` shall not be set.
     public static let bodyMovementDetectionSupported = BloodPressureFeature(rawValue: 1 << 0)
+    /// Indicate if the cuff fit detection is supported.
+    ///
+    /// If supported, use the ``BloodPressureMeasurement/Status/looseCuffFit`` field to indicate if
+    /// loose cuff fit was detected.
+    /// If not supported, the ``BloodPressureMeasurement/Status/looseCuffFit`` shall not be set.
     public static let cuffFitDetectionSupported = BloodPressureFeature(rawValue: 1 << 1)
+    /// Indicate if the irregular pulse detection is supported.
+    ///
+    /// If supported, use the ``BloodPressureMeasurement/Status/irregularPulse`` field to indicate if
+    /// irregular pulse was detected.
+    /// If not supported, the ``BloodPressureMeasurement/Status/irregularPulse`` shall not be set.
     public static let irregularPulseDetectionSupported = BloodPressureFeature(rawValue: 1 << 2)
+    /// Indicate if the pulse rate range detection is supported.
+    ///
+    /// If supported, use the ``BloodPressureMeasurement/Status/pulseRateBelowLowerLimit`` or
+    /// ``BloodPressureMeasurement/Status/pulseRateExceedsUpperLimit`` fields to indicate if
+    /// if a pulse rate was detected that was out of range.
+    /// If not supported, the ``BloodPressureMeasurement/Status/pulseRateBelowLowerLimit``
+    /// or ``BloodPressureMeasurement/Status/pulseRateExceedsUpperLimit`` shall not be set.
     public static let pulseRateRangeDetectionSupported = BloodPressureFeature(rawValue: 1 << 3)
+    /// Indicate if measurement position detection is supported.
+    ///
+    /// If supported, use the ``BloodPressureMeasurement/Status/improperMeasurementPosition`` field to indicate
+    /// a improper measurement position.
+    /// If not supported, the ``BloodPressureMeasurement/Status/improperMeasurementPosition`` shall not be set.
     public static let measurementPositionDetectionSupported = BloodPressureFeature(rawValue: 1 << 4)
+    /// Indicate if the blood pressure sensor supports multiple bonds.
     public static let multipleBondsSupported = BloodPressureFeature(rawValue: 1 << 5)
+    /// Indicate if the sensors supports E2E protection of blood pressure records with an E2E-CRC.
     public static let e2eCrcSupported = BloodPressureFeature(rawValue: 1 << 6)
+    /// Indicate if the User Data Service is supported.
     public static let userDataServiceSupported = BloodPressureFeature(rawValue: 1 << 7)
+    /// Indicate if Device Time and User Facing Time reporting using Device Time Service (v1.0 or later).
     public static let userFacingTimeSupported = BloodPressureFeature(rawValue: 1 << 8)
+
 
     public init(rawValue: UInt16) {
         self.rawValue = rawValue

--- a/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
@@ -1,0 +1,49 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+public struct BloodPressureFeature: OptionSet {
+    public var rawValue: UInt16
+
+    // TODO: docs
+
+    public static let bodyMovementDetectionSupported = BloodPressureFeature(rawValue: 1 << 0)
+    public static let cuffFitDetectionSupported = BloodPressureFeature(rawValue: 1 << 1)
+    public static let irregularPulseDetectionSupported = BloodPressureFeature(rawValue: 1 << 2)
+    public static let pulseRateRangeDetectionSupported = BloodPressureFeature(rawValue: 1 << 3)
+    public static let measurementPositionDetectionSupported = BloodPressureFeature(rawValue: 1 << 4)
+    public static let multipleBondsSupported = BloodPressureFeature(rawValue: 1 << 5)
+    public static let e2eCrcSupported = BloodPressureFeature(rawValue: 1 << 6)
+    public static let userDataServiceSupported = BloodPressureFeature(rawValue: 1 << 7)
+    public static let userFacingTimeSupported = BloodPressureFeature(rawValue: 1 << 8)
+
+    public init(rawValue: UInt16) {
+        self.rawValue = rawValue
+    }
+}
+
+
+extension BloodPressureFeature: Hashable, Sendable {}
+
+
+extension BloodPressureFeature: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -87,7 +87,7 @@ public struct BloodPressureMeasurement {
 
     /// The associated user of the blood pressure measurement.
     ///
-    /// This value can be used to differantiate users if the device supports multiple users.
+    /// This value can be used to differentiate users if the device supports multiple users.
     /// - Note: The special value of `0xFF` (`UInt8.max`) is used to represent an unknown user.
     ///
     /// The values are left to the implementation but should be unique per device.
@@ -111,10 +111,10 @@ public struct BloodPressureMeasurement {
     ///   - pulseRate: The pulse rate in in beats per minute.
     ///     An unavailable value can be indicated using ``MedFloat16.nan``.
     ///   - userId: The associated user of the blood pressure measurement.
-    ///   - measurementStatus: Additional meatadata information of the measurement.
+    ///   - measurementStatus: Additional metadata information of the measurement.
     public init(
-        systolicValue: MedFloat16,
-        diastolicValue: MedFloat16,
+        systolic systolicValue: MedFloat16,
+        diastolic diastolicValue: MedFloat16,
         meanArterialPressure: MedFloat16,
         unit: Unit,
         timeStamp: DateTime? = nil,

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -11,6 +11,9 @@ import Foundation
 import NIO
 
 
+/// A blood pressure measurement.
+///
+/// Refer to GATT Specification Supplement, 3.31 Blood Pressure Measurement.
 public struct BloodPressureMeasurement {
     fileprivate struct Flags: OptionSet {
         let rawValue: UInt8
@@ -27,7 +30,7 @@ public struct BloodPressureMeasurement {
     }
 
     /// The unit of a blood pressure measurement.
-    public enum Unit { // TODO: apply similar style to temperature measurement!
+    public enum Unit {
         /// Blood pressure for Systolic, Diastolic and Mean Arterial Pressure (MAP) is in units of mmHg.
         case mmHg
         /// Blood pressure for Systolic, Diastolic and Mean Arterial Pressure (MAP) is in units of kPa.
@@ -47,7 +50,7 @@ public struct BloodPressureMeasurement {
         /// Irregular pulse detected.
         public static let irregularPulse = Status(rawValue: 1 << 2)
         /// Pulse rate exceeds upper limit.
-        public static let pulseRateExceedsUpperLimit = Status(rawValue: 1 << 3) // TODO: are these two switched?
+        public static let pulseRateExceedsUpperLimit = Status(rawValue: 1 << 3)
         /// Pulse rate is less than lower limit.
         public static let pulseRateBelowLowerLimit = Status(rawValue: 1 << 4)
         /// Improper measurement position detected.
@@ -59,21 +62,86 @@ public struct BloodPressureMeasurement {
         }
     }
 
+    /// The systolic value of the blood pressure measurement.
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
     public let systolicValue: MedFloat16
+    /// The diastolic value of the blood pressure measurement.
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
     public let diastolicValue: MedFloat16
+    /// The Mean Arterial Pressure (MAP)
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
     public let meanArterialPressure: MedFloat16
+    /// The unit of the blood pressure measurement values.
+    ///
+    /// This property defines the unit of the ``systolicValue``, ``diastolicValue`` and ``meanArterialPressure`` properties.
     public let unit: Unit
 
+    /// The timestamp of the measurement.
     public let timeStamp: DateTime?
 
+    /// The pulse rate in beats per minute.
     public let pulseRate: MedFloat16?
 
-    public let userId: UInt8? // TODO: checkout usage and behavior
+    /// The associated user of the blood pressure measurement.
+    ///
+    /// This value can be used to differantiate users if the device supports multiple users.
+    /// - Note: The special value of `0xFF` (`UInt8.max`) is used to represent an unknown user.
+    ///
+    /// The values are left to the implementation but should be unique per device.
+    public let userId: UInt8?
 
+    /// Additional metadata information of a blood pressure measurement.
     public let measurementStatus: Status?
+
+
+    /// Create a new blood pressure measurement.
+    /// - Parameters:
+    ///   - systolicValue: The systolic blood pressure value.
+    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///   - diastolicValue: The diastolic blood pressure value.
+    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///   - meanArterialPressure: The mean arterial pressure.
+    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///   - unit: The unit for the systolic, diastolic and mean arterial pressure values.
+    ///   - timeStamp: The timestamp of the measurement.
+    ///     The value should be provided if the device supports storage of data.
+    ///   - pulseRate: The pulse rate in in beats per minute.
+    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///   - userId: The associated user of the blood pressure measurement.
+    ///   - measurementStatus: Additional meatadata information of the measurement.
+    public init(
+        systolicValue: MedFloat16,
+        diastolicValue: MedFloat16,
+        meanArterialPressure: MedFloat16,
+        unit: Unit,
+        timeStamp: DateTime? = nil,
+        pulseRate: MedFloat16? = nil,
+        userId: UInt8? = nil,
+        measurementStatus: Status? = nil
+    ) {
+        self.systolicValue = systolicValue
+        self.diastolicValue = diastolicValue
+        self.meanArterialPressure = meanArterialPressure
+        self.unit = unit
+        self.timeStamp = timeStamp
+        self.pulseRate = pulseRate
+        self.userId = userId
+        self.measurementStatus = measurementStatus
+    }
 }
 
-// TODO: equtable and sendable conformance!
+
+extension BloodPressureMeasurement.Unit: Sendable, Hashable {}
+
+
+extension BloodPressureMeasurement.Status: Sendable, Hashable {}
+
+
+extension BloodPressureMeasurement: Sendable, Hashable {}
+
 
 extension BloodPressureMeasurement.Flags: ByteCodable {
     init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -1,0 +1,199 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIO
+
+
+public struct BloodPressureMeasurement {
+    fileprivate struct Flags: OptionSet {
+        let rawValue: UInt8
+
+        static let kPaUnit = Flags(rawValue: 1 << 0)
+        static let timeStampPresent = Flags(rawValue: 1 << 1)
+        static let pulseRatePresent = Flags(rawValue: 1 << 2)
+        static let userIdPresent = Flags(rawValue: 1 << 3)
+        static let measurementStatusPresent = Flags(rawValue: 1 << 4)
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// The unit of a blood pressure measurement.
+    public enum Unit { // TODO: apply similar style to temperature measurement!
+        /// Blood pressure for Systolic, Diastolic and Mean Arterial Pressure (MAP) is in units of mmHg.
+        case mmHg
+        /// Blood pressure for Systolic, Diastolic and Mean Arterial Pressure (MAP) is in units of kPa.
+        case kPa
+    }
+
+    /// Measurement Status of blood pressure measurement.
+    ///
+    /// Refer to GATT Specification Supplement, 3.31.3 Measurement Status field.
+    public struct Status: OptionSet {
+        public let rawValue: UInt16
+
+        /// Body movement detected during measurement.
+        public static let bodyMovementDetected = Status(rawValue: 1 << 0)
+        /// Cuff fit detection detected cuff too loose.
+        public static let looseCuffFit = Status(rawValue: 1 << 1)
+        /// Irregular pulse detected.
+        public static let irregularPulse = Status(rawValue: 1 << 2)
+        /// Pulse rate exceeds upper limit.
+        public static let pulseRateExceedsUpperLimit = Status(rawValue: 1 << 3) // TODO: are these two switched?
+        /// Pulse rate is less than lower limit.
+        public static let pulseRateBelowLowerLimit = Status(rawValue: 1 << 4)
+        /// Improper measurement position detected.
+        public static let improperMeasurementPosition = Status(rawValue: 1 << 5)
+
+        /// Initialize new status option set.
+        public init(rawValue: UInt16) {
+            self.rawValue = rawValue
+        }
+    }
+
+    public let systolicValue: MedFloat16
+    public let diastolicValue: MedFloat16
+    public let meanArterialPressure: MedFloat16
+    public let unit: Unit
+
+    public let timeStamp: DateTime?
+
+    public let pulseRate: MedFloat16?
+
+    public let userId: UInt8? // TODO: checkout usage and behavior
+
+    public let measurementStatus: Status?
+}
+
+// TODO: equtable and sendable conformance!
+
+extension BloodPressureMeasurement.Flags: ByteCodable {
+    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+extension BloodPressureMeasurement.Status: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+extension BloodPressureMeasurement: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
+              let systolicValue = MedFloat16(from: &byteBuffer, preferredEndianness: endianness),
+              let diastolicValue = MedFloat16(from: &byteBuffer, preferredEndianness: endianness),
+              let meanArterialPressure = MedFloat16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.systolicValue = systolicValue
+        self.diastolicValue = diastolicValue
+        self.meanArterialPressure = meanArterialPressure
+
+        if flags.contains(.kPaUnit) {
+            self.unit = .kPa
+        } else {
+            self.unit = .mmHg
+        }
+
+        if flags.contains(.timeStampPresent) {
+            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.timeStamp = timeStamp
+        } else {
+            self.timeStamp = nil
+        }
+
+        if flags.contains(.pulseRatePresent) {
+            guard let pulseRate = MedFloat16(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.pulseRate = pulseRate
+        } else {
+            self.pulseRate = nil
+        }
+
+        if flags.contains(.userIdPresent) {
+            guard let userId = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.userId = userId
+        } else {
+            self.userId = nil
+        }
+
+        if flags.contains(.measurementStatusPresent) {
+            guard let status = Status(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.measurementStatus = status
+        } else {
+            self.measurementStatus = nil
+        }
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        var flags: Flags = []
+
+        // write empty flags field for now to move writer index
+        let flagsIndex = byteBuffer.writerIndex
+        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
+
+        systolicValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+        diastolicValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+        meanArterialPressure.encode(to: &byteBuffer, preferredEndianness: endianness)
+
+        if case .kPa = unit {
+            flags.insert(.kPaUnit)
+        }
+
+        if let timeStamp {
+            flags.insert(.timeStampPresent)
+            timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        if let pulseRate {
+            flags.insert(.pulseRatePresent)
+            pulseRate.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        if let userId {
+            flags.insert(.userIdPresent)
+            userId.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        if let measurementStatus {
+            flags.insert(.measurementStatusPresent)
+            measurementStatus.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -14,7 +14,7 @@ import NIO
 /// A blood pressure measurement.
 ///
 /// Refer to GATT Specification Supplement, 3.31 Blood Pressure Measurement.
-public struct BloodPressureMeasurement { // TODO: characteristics tests
+public struct BloodPressureMeasurement {
     fileprivate struct Flags: OptionSet {
         let rawValue: UInt8
 

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -14,7 +14,7 @@ import NIO
 /// A blood pressure measurement.
 ///
 /// Refer to GATT Specification Supplement, 3.31 Blood Pressure Measurement.
-public struct BloodPressureMeasurement {
+public struct BloodPressureMeasurement { // TODO: characteristics tests
     fileprivate struct Flags: OptionSet {
         let rawValue: UInt8
 

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -100,16 +100,16 @@ public struct BloodPressureMeasurement {
     /// Create a new blood pressure measurement.
     /// - Parameters:
     ///   - systolicValue: The systolic blood pressure value.
-    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///     An unavailable value can be indicated using ``MedFloat16/nan``.
     ///   - diastolicValue: The diastolic blood pressure value.
-    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///     An unavailable value can be indicated using ``MedFloat16/nan``.
     ///   - meanArterialPressure: The mean arterial pressure.
-    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///     An unavailable value can be indicated using ``MedFloat16/nan``.
     ///   - unit: The unit for the systolic, diastolic and mean arterial pressure values.
     ///   - timeStamp: The timestamp of the measurement.
     ///     The value should be provided if the device supports storage of data.
     ///   - pulseRate: The pulse rate in in beats per minute.
-    ///     An unavailable value can be indicated using ``MedFloat16.nan``.
+    ///     An unavailable value can be indicated using ``MedFloat16/nan``.
     ///   - userId: The associated user of the blood pressure measurement.
     ///   - measurementStatus: Additional metadata information of the measurement.
     public init(

--- a/Sources/BluetoothServices/Characteristics/DateTime.swift
+++ b/Sources/BluetoothServices/Characteristics/DateTime.swift
@@ -92,10 +92,10 @@ public struct DateTime {
 }
 
 
-extension DateTime.Month: Equatable {}
+extension DateTime.Month: Hashable, Sendable {}
 
 
-extension DateTime: Equatable {}
+extension DateTime: Hashable, Sendable {}
 
 
 extension DateTime.Month: ByteCodable {

--- a/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
+++ b/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
@@ -99,7 +99,17 @@ public struct IntermediateCuffPressure {
 }
 
 
-extension IntermediateCuffPressure: Hashable, Sendable {}
+extension IntermediateCuffPressure: Hashable, Sendable {
+    public static func == (lhs: IntermediateCuffPressure, rhs: IntermediateCuffPressure) -> Bool {
+        // we need to override the implementation to avoid weird behavior with NaNs
+        lhs.currentCuffPressure == rhs.currentCuffPressure
+            && lhs.unit == rhs.unit
+            && lhs.timestamp == rhs.timestamp
+            && lhs.pulseRate == rhs.pulseRate
+            && lhs.userId == rhs.userId
+            && lhs.measurementStatus == rhs.measurementStatus
+    }
+}
 
 
 extension IntermediateCuffPressure: ByteCodable {

--- a/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
+++ b/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
@@ -1,0 +1,117 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// Intermediate cuff pressure values while  a measurement is in progress.
+///
+/// The intermediate cuff pressure characteristic is used to send intermediate cuff pressure values to a device
+/// for displaying purposes while a blood pressure measurement is in progress.
+///
+/// Refer to GATT Specification Supplement, 3.126 Intermediate Cuff Pressure.
+public struct IntermediateCuffPressure {
+    /// The  intermediate cuff pressure has the same format as the blood pressure measurement characteristic.
+    ///
+    /// Some of the fields have different semantics in the context of the intermediate cuff pressure characteristic.
+    /// The systolic blood pressure field is used as the current cuff pressure, while the other fields (diastolic and mean arterial pressure)
+    /// are unused and are set to NaN.
+    private let representation: BloodPressureMeasurement
+
+    /// The current cuff pressure.
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
+    public var currentCuffPressure: MedFloat16 {
+        representation.systolicValue
+    }
+
+    /// The unit of the current cuff pressure.
+    public var unit: BloodPressureMeasurement.Unit {
+        representation.unit
+    }
+
+    /// Timestamp that may be included.
+    ///
+    /// It is recommended to not be used to avoid sending unnecessary data.
+    public var timestamp: DateTime? {
+        representation.timeStamp
+    }
+
+    /// The current pulse rate.
+    ///
+    /// It is recommended to not be used to avoid sending unnecessary data.
+    public var pulseRate: MedFloat16? {
+        representation.pulseRate
+    }
+
+    /// The associated user of the blood pressure measurement.
+    ///
+    /// This value can be used to differentiate users if the device supports multiple users.
+    /// - Note: The special value of `0xFF` (`UInt8.max`) is used to represent an unknown user.
+    ///
+    /// The values are left to the implementation but should be unique per device.
+    public var userId: UInt8? {
+        representation.userId
+    }
+
+    /// Additional metadata information of a blood pressure measurement.
+    public var measurementStatus: BloodPressureMeasurement.Status? {
+        representation.measurementStatus
+    }
+
+
+    /// Create a new intermediate cuff pressure value.
+    /// - Parameters:
+    ///   - currentCuffPressure: The current cuff pressure.
+    ///   - unit: The unit of the current cuff pressure.
+    ///   - timeStamp: The timestamp of the measurement.
+    ///     Do not provide a value to avoid transmitting unnecessary data.
+    ///   - pulseRate: The current pulse rate.
+    ///     Do not provide a value to avoid transmitting unnecessary data.
+    ///   - userId: The associated user of the blood pressure measurement.
+    ///   - measurementStatus: Additional metadata information of the measurement.
+    public init(
+        currentCuffPressure: MedFloat16,
+        unit: BloodPressureMeasurement.Unit,
+        timeStamp: DateTime? = nil,
+        pulseRate: MedFloat16? = nil,
+        userId: UInt8? = nil,
+        measurementStatus: BloodPressureMeasurement.Status? = nil
+    ) {
+        self.representation = BloodPressureMeasurement(
+            systolic: currentCuffPressure,
+            diastolic: .nan,
+            meanArterialPressure: .nan,
+            unit: unit,
+            timeStamp: timeStamp,
+            pulseRate: pulseRate,
+            userId: userId,
+            measurementStatus: measurementStatus
+        )
+    }
+}
+
+
+extension IntermediateCuffPressure: Hashable, Sendable {}
+
+
+extension IntermediateCuffPressure: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let representation = BloodPressureMeasurement(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.representation = representation
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        representation.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/MeasurementInterval.swift
+++ b/Sources/BluetoothServices/Characteristics/MeasurementInterval.swift
@@ -21,7 +21,7 @@ public enum MeasurementInterval {
 }
 
 
-extension MeasurementInterval: Equatable {}
+extension MeasurementInterval: Hashable, Sendable {}
 
 
 extension MeasurementInterval: RawRepresentable {

--- a/Sources/BluetoothServices/Characteristics/PnPID.swift
+++ b/Sources/BluetoothServices/Characteristics/PnPID.swift
@@ -64,10 +64,10 @@ public struct PnPID {
 }
 
 
-extension VendorIDSource: Equatable {}
+extension VendorIDSource: Hashable, Sendable {}
 
 
-extension PnPID: Equatable {}
+extension PnPID: Hashable, Sendable {}
 
 
 extension VendorIDSource: RawRepresentable {

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -18,7 +18,7 @@ public struct TemperatureMeasurement {
     /// The temperature value encoded as `medfloat32`.
     public enum Value {
         /// The temperature value in celsius.
-        case celsius(_ medfloat32: Data)
+        case celsius(_ medfloat32: Data) // TODO: Support medfloat32
         /// The temperature value in fahrenheit.
         case fahrenheit(_ medfloat32: Data)
 
@@ -55,7 +55,7 @@ public struct TemperatureMeasurement {
 
 
 extension TemperatureMeasurement {
-    private enum FlagsField {
+    private enum FlagsField { // TODO: optionset???
         static let isFahrenheitTemperature: UInt8 = 0x01
         static let isTimeStampPresent: UInt8 = 0x02
         static let isTemperatureTypePresent: UInt8 = 0x04
@@ -63,6 +63,7 @@ extension TemperatureMeasurement {
 }
 
 
+// TODO: Sendable conformance everywhere!
 extension TemperatureMeasurement.Value: Equatable {}
 
 

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -38,10 +38,10 @@ public struct TemperatureMeasurement {
     /// The temperature value encoded as a `medfloat32`.
     ///
     /// The unit of this value is defined by the ``unit-swift.property`` property.
-    public let value: UInt32 // TODO: rename!
+    public let temperature: UInt32 // TODO: rename!
     /// The unit of the temperature value .
     ///
-    /// This property defined the unit of the ``value`` property.
+    /// This property defined the unit of the ``temperature`` property.
     public let unit: Unit
 
     /// The timestamp of the recording.
@@ -52,12 +52,12 @@ public struct TemperatureMeasurement {
 
     /// Create a new temperature measurement.
     /// - Parameters:
-    ///   - value: The measurement value as a medfloat32.
+    ///   - temperature: The measurement value as a medfloat32.
     ///   - unit: The unit of the temperature measurement.
     ///   - timeStamp: The timestamp of the measurement.
     ///   - temperatureType: The type of the measurement.
-    public init(value: UInt32, unit: Unit, timeStamp: DateTime? = nil, temperatureType: TemperatureType? = nil) {
-        self.value = value
+    public init(temperature: UInt32, unit: Unit, timeStamp: DateTime? = nil, temperatureType: TemperatureType? = nil) {
+        self.temperature = temperature
         self.unit = unit
         self.timeStamp = timeStamp
         self.temperatureType = temperatureType
@@ -87,11 +87,11 @@ extension TemperatureMeasurement.Flags: ByteCodable {
 extension TemperatureMeasurement: ByteCodable {
     public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
         guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
-              let value = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
+              let temperature = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
             return nil
         }
 
-        self.value = value
+        self.temperature = temperature
 
         if flags.contains(.fahrenheitUnit) {
             self.unit = .fahrenheit
@@ -125,7 +125,7 @@ extension TemperatureMeasurement: ByteCodable {
         let flagsIndex = byteBuffer.writerIndex
         flags.encode(to: &byteBuffer, preferredEndianness: endianness)
 
-        value.encode(to: &byteBuffer, preferredEndianness: endianness)
+        temperature.encode(to: &byteBuffer, preferredEndianness: endianness)
 
         if case .fahrenheit = unit {
             flags.insert(.fahrenheitUnit)

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -38,7 +38,7 @@ public struct TemperatureMeasurement {
     /// The temperature value encoded as a `medfloat32`.
     ///
     /// The unit of this value is defined by the ``unit-swift.property`` property.
-    public let temperature: UInt32 // TODO: rename!
+    public let temperature: UInt32
     /// The unit of the temperature value .
     ///
     /// This property defined the unit of the ``temperature`` property.

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -15,25 +15,35 @@ import NIO
 ///
 /// Refer to GATT Specification Supplement, 3.216 Temperature Measurement.
 public struct TemperatureMeasurement {
-    /// The temperature value encoded as `medfloat32`.
-    public enum Value {
-        /// The temperature value in celsius.
-        case celsius(_ medfloat32: Data) // TODO: Support medfloat32
-        /// The temperature value in fahrenheit.
-        case fahrenheit(_ medfloat32: Data)
+    fileprivate struct Flags: OptionSet {
+        let rawValue: UInt8
 
-        var data: Data {
-            switch self {
-            case let .fahrenheit(data):
-                data
-            case let .celsius(data):
-                data
-            }
+        static let fahrenheitUnit = Flags(rawValue: 1 << 0)
+        static let timeStampPresent = Flags(rawValue: 1 << 1)
+        static let temperatureTypePresent = Flags(rawValue: 1 << 2)
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
         }
     }
 
+    /// The unit of a temperature measurement.
+    public enum Unit {
+        /// The temperature value is measured in celsius.
+        case celsius
+        /// The temperature value is measured in fahrenheit.
+        case fahrenheit
+    }
+
     /// The temperature value encoded as a `medfloat32`.
-    public let value: Value
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
+    public let value: UInt32
+    /// The unit of the temperature value .
+    ///
+    /// This property defined the unit of the ``value`` property.
+    public let unit: Unit
+
     /// The timestamp of the recording.
     public let timeStamp: DateTime?
     /// The location of the temperature measurement.
@@ -42,92 +52,95 @@ public struct TemperatureMeasurement {
 
     /// Create a new temperature measurement.
     /// - Parameters:
-    ///   - value: The measurement value.
+    ///   - value: The measurement value as a medfloat32.
+    ///   - unit: The unit of the temperature measurement.
     ///   - timeStamp: The timestamp of the measurement.
     ///   - temperatureType: The type of the measurement.
-    public init(value: Value, timeStamp: DateTime? = nil, temperatureType: TemperatureType? = nil) {
+    public init(value: UInt32, unit: Unit, timeStamp: DateTime? = nil, temperatureType: TemperatureType? = nil) {
         self.value = value
+        self.unit = unit
         self.timeStamp = timeStamp
         self.temperatureType = temperatureType
-        assert(value.data.count == 4, "medFloat32 must be of length 4. Found \(value.data.count) bytes!")
     }
 }
 
 
-extension TemperatureMeasurement {
-    private enum FlagsField { // TODO: optionset???
-        static let isFahrenheitTemperature: UInt8 = 0x01
-        static let isTimeStampPresent: UInt8 = 0x02
-        static let isTemperatureTypePresent: UInt8 = 0x04
+extension TemperatureMeasurement.Unit: Sendable, Hashable {}
+
+
+extension TemperatureMeasurement: Sendable, Hashable {}
+
+
+extension TemperatureMeasurement.Flags: ByteCodable {
+    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
     }
 }
-
-
-// TODO: Sendable conformance everywhere!
-extension TemperatureMeasurement.Value: Equatable {}
-
-
-extension TemperatureMeasurement: Equatable {}
-
 
 extension TemperatureMeasurement: ByteCodable {
     public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let flags = UInt8(from: &byteBuffer, preferredEndianness: endianness),
-              let medFloat32 = byteBuffer.readData(length: 4) else {
+        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
+              let value = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
             return nil
         }
 
-        let measurement: Value
-        var timeStamp: DateTime?
-        var temperatureType: TemperatureType?
+        self.value = value
 
-        if flags & FlagsField.isFahrenheitTemperature > 0 {
-            measurement = .fahrenheit(medFloat32)
+        if flags.contains(.fahrenheitUnit) {
+            self.unit = .fahrenheit
         } else {
-            measurement = .celsius(medFloat32)
+            self.unit = .celsius
         }
 
-        if flags & FlagsField.isTimeStampPresent > 0 {
-            guard let dateTime = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+        if flags.contains(.timeStampPresent) {
+            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
                 return nil
             }
-            timeStamp = dateTime
+            self.timeStamp = timeStamp
+        } else {
+            self.timeStamp = nil
         }
 
-        if flags & FlagsField.isTemperatureTypePresent > 0 {
-            guard let type = TemperatureType(from: &byteBuffer, preferredEndianness: endianness) else {
+        if flags.contains(.temperatureTypePresent) {
+            guard let temperatureType = TemperatureType(from: &byteBuffer, preferredEndianness: endianness) else {
                 return nil
             }
-            temperatureType = type
+            self.temperatureType = temperatureType
+        } else {
+            self.temperatureType = nil
         }
-
-        self.init(value: measurement, timeStamp: timeStamp, temperatureType: temperatureType)
     }
 
     public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        var flags: Flags = []
+
+        // write empty flags field for now to move writer index
         let flagsIndex = byteBuffer.writerIndex
-        var flags: UInt8 = 0
+        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
 
-        flags.encode(to: &byteBuffer, preferredEndianness: endianness) // write for now
+        value.encode(to: &byteBuffer, preferredEndianness: endianness)
 
-        switch value {
-        case let .fahrenheit(data):
-            flags |= FlagsField.isFahrenheitTemperature
-            data.encode(to: &byteBuffer, preferredEndianness: endianness)
-        case let .celsius(data):
-            data.encode(to: &byteBuffer, preferredEndianness: endianness)
+        if case .fahrenheit = unit {
+            flags.insert(.fahrenheitUnit)
         }
 
         if let timeStamp {
-            flags |= FlagsField.isTimeStampPresent
+            flags.insert(.timeStampPresent)
             timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
         }
 
         if let temperatureType {
-            flags |= FlagsField.isTemperatureTypePresent
+            flags.insert(.temperatureTypePresent)
             temperatureType.encode(to: &byteBuffer, preferredEndianness: endianness)
         }
 
-        byteBuffer.setInteger(flags, at: flagsIndex) // finally update the flags field
+        byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field
     }
 }

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -38,7 +38,7 @@ public struct TemperatureMeasurement {
     /// The temperature value encoded as a `medfloat32`.
     ///
     /// The unit of this value is defined by the ``unit-swift.property`` property.
-    public let value: UInt32
+    public let value: UInt32 // TODO: rename!
     /// The unit of the temperature value .
     ///
     /// This property defined the unit of the ``value`` property.

--- a/Sources/BluetoothServices/Characteristics/TemperatureType.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureType.swift
@@ -37,7 +37,7 @@ public enum TemperatureType: UInt8, CaseIterable {
 }
 
 
-extension TemperatureType: Equatable {}
+extension TemperatureType: Hashable, Sendable {}
 
 
 extension TemperatureType: ByteCodable {

--- a/Sources/BluetoothServices/DeviceInformationService.swift
+++ b/Sources/BluetoothServices/DeviceInformationService.swift
@@ -17,12 +17,6 @@ import SpeziBluetooth
 /// All characteristics are read-only and optional to implement.
 /// It is possible that none are implemented at all.
 /// For more information refer to the specification.
-///
-/// ## Topics
-///
-/// ### Structures
-/// - ``PnPID``
-/// - ``VendorIDSource``
 public final class DeviceInformationService: BluetoothService, @unchecked Sendable {
     public static let id = CBUUID(string: "180A")
 

--- a/Sources/BluetoothServices/HealthThermometerService.swift
+++ b/Sources/BluetoothServices/HealthThermometerService.swift
@@ -13,14 +13,6 @@ import SpeziBluetooth
 /// Bluetooth Health Thermometer Service implementation.
 ///
 /// This class implements the Bluetooth [Health Thermometer Service 1.0](https://www.bluetooth.com/specifications/specs/health-thermometer-service-1-0).
-///
-/// ## Topics
-///
-/// ### Structures
-/// - ``TemperatureMeasurement``
-/// - ``TemperatureType``
-/// - ``MeasurementInterval``
-/// - ``DateTime``
 public final class HealthThermometerService: BluetoothService, @unchecked Sendable {
     public static let id = CBUUID(string: "1809")
 

--- a/Sources/BluetoothServices/MedFloat16.swift
+++ b/Sources/BluetoothServices/MedFloat16.swift
@@ -204,8 +204,7 @@ extension MedFloat16 {
     }
 
     func normalized() -> MedFloat16 {
-        var exponent = exponent
-        var mantissa = mantissa
+        // MedFloat16.normalize is called as part of the initializer
         return MedFloat16(exponent: exponent, mantissa: mantissa)
     }
 }

--- a/Sources/BluetoothServices/MedFloat16.swift
+++ b/Sources/BluetoothServices/MedFloat16.swift
@@ -447,7 +447,7 @@ extension MedFloat16: ExpressibleByIntegerLiteral {
 extension MedFloat16: AdditiveArithmetic {
     public static func + (lhs: MedFloat16, rhs: MedFloat16) -> MedFloat16 {
         // We are going the cheap route here! There, is way too much to check for otherwise.
-        return MedFloat16(lhs.double + rhs.double)
+        MedFloat16(lhs.double + rhs.double)
     }
 
     public static func - (lhs: MedFloat16, rhs: MedFloat16) -> MedFloat16 {
@@ -507,7 +507,7 @@ extension MedFloat16: Numeric {
 
     public static func * (lhs: MedFloat16, rhs: MedFloat16) -> MedFloat16 {
         // We are going the cheap route here! There, is way too much to check for otherwise.
-        return MedFloat16(lhs.double * rhs.double)
+        MedFloat16(lhs.double * rhs.double)
     }
 
     public static func *= (lhs: inout MedFloat16, rhs: MedFloat16) {
@@ -591,3 +591,5 @@ extension Int16 {
     /// `MedFloat16.negativeInfinity + 1` but with most significant byte adjusted to Int16 representation.
     fileprivate static let medFloat16mantissaMin = Int16(bitPattern: 0xF803)
 }
+
+// swiftlint:disable:this file_length

--- a/Sources/BluetoothServices/MedFloat16.swift
+++ b/Sources/BluetoothServices/MedFloat16.swift
@@ -205,7 +205,7 @@ extension MedFloat16 {
 
     func normalized() -> MedFloat16 {
         // MedFloat16.normalize is called as part of the initializer
-        return MedFloat16(exponent: exponent, mantissa: mantissa)
+        MedFloat16(exponent: exponent, mantissa: mantissa)
     }
 }
 

--- a/Sources/BluetoothServices/MedFloat16.swift
+++ b/Sources/BluetoothServices/MedFloat16.swift
@@ -1,0 +1,333 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+// TODO: move file?? SpeziNetworking (finally?)
+
+// TODO: protocol?
+
+/// Medical 16-bit float representation using base 10.
+///
+/// The `MedFloat16` (or SFLOAT-Type) is a 16-bit value that uses 4-bit signed exponent to base 10 and 12-bit signed mantissa.
+/// It can be used to accurately store decimal digits of base 10 decimal integers.
+///
+/// The value of the medfloat can be calculated using the the following formula, where `**` is exponentiation:
+///
+///         x.mantissa * (10 ** x.exponent)
+public struct MedFloat16 {
+    /// The bit pattern of the medfloat.
+    public let bitPattern: UInt16
+
+    /// The 4-bit signed exponent.
+    ///
+    /// The 4-bit signed exponent in two's complement, adjusted to Int8 two's complement representation.
+    public var exponent: Int8 {
+        var exponentBitPattern = UInt8(bitPattern >> 12)
+
+        // We need to correct Int4 two's complement representation to Int8 two's complement:
+        // If its larger than the largest positive uint4 number, we want to make sure that all upper 8 bits are flipped
+        // in the int8 representation.
+        if exponentBitPattern > MedFloat16.maxInt4 {
+            exponentBitPattern |= 0xF0
+        }
+
+        return Int8(bitPattern: exponentBitPattern)
+    }
+
+    /// The 12-bit signed exponent.
+    ///
+    /// The 12-bit signed exponent in two's complement, adjusted to Int16 two's complement representation.
+    public var mantissa: Int16 {
+        var mantissaBitPattern = bitPattern & 0x0FFF
+
+        // See explanation in `exponent`. We correct Int12 two's complement representation to Int16 two's complement.
+        if mantissaBitPattern > MedFloat16.maxInt12 {
+            mantissaBitPattern |= 0xF000
+        }
+
+        return Int16(bitPattern: mantissaBitPattern)
+    }
+
+
+    /// Double approximation of the medfloat.
+    public var double: Double {
+        switch bitPattern {
+        case MedFloat16.nan.bitPattern, MedFloat16.nres.bitPattern, MedFloat16.reserved0.bitPattern:
+            return .nan
+        case MedFloat16.infinity.bitPattern:
+            return .infinity
+        case MedFloat16.negativeInfinity.bitPattern:
+            return -Double.infinity
+        default:
+            break
+        }
+
+        // TODO: properly convert to reserved Doubles?
+        let magnitude = pow(10.0, Double(exponent))
+
+        return Double(mantissa) * magnitude
+    }
+
+    /// Float approximation of the medfloat.
+    public var float: Float { // TODO: do we want to support that?
+        // using the double value for best precision in the conversion.
+        Float(double)
+    }
+
+
+    /// Initialize a medfloat from its 16-bit bit pattern.
+    /// - Parameter bitPattern: The bit pattern as a unsigned, 16-bit integer.
+    public init(bitPattern: UInt16) {
+        self.bitPattern = bitPattern
+    }
+
+
+    /// Derive a medfloat16 from its exponent and mantissa.
+    ///
+    /// The value of the medfloat can be calculated using the the following formula, where `**` is exponentiation:
+    ///
+    ///         x.mantissa * (10 ** x.exponent)
+    ///
+    /// - Note: The `exponent` and `mantissa` are constrained to `Int4` and `Int12` resolution respectively.
+    ///     Passing values exceeding this ranges will result in a ``nres`` value.
+    ///
+    /// - Note: Be aware that the closed range of `0x7FE`-`0x802` as the `mantissa` with an `exponent` of  zero are used
+    ///     to represent special values like NaN, nRes or infinity.
+    ///
+    /// - Parameters:
+    ///   - exponent: The signed Int4 exponent of the medfloat.
+    ///   - mantissa: The signed Int12 exponent of the medfloat.
+    public init(exponent: Int8, mantissa: Int16) {
+        // check that exponent and mantissa are not out of range.
+        if exponent > MedFloat16.maxInt4 || exponent < MedFloat16.minInt4
+            || mantissa > MedFloat16.maxInt12 || mantissa < MedFloat16.minInt12 {
+            self = .nres // TODO: what is +- infinity used then?
+            return
+        }
+
+        let exponentBitPattern = UInt8(bitPattern: exponent) & 0x0F
+        let mantissaBitPattern = UInt16(bitPattern: mantissa) & 0x0FFF
+
+        self.init(bitPattern: (UInt16(exponentBitPattern) << 12) | mantissaBitPattern)
+    }
+
+    // TODO: can we convert from a e.g., double? se bytelib implementation
+}
+
+
+extension MedFloat16 {
+    public static let zero = MedFloat16(bitPattern: 0)
+
+    /// Indicates invalid result.
+    ///
+    /// Indicates a invalid result form a computation step or to indicate missing data due to the hardware's inability to provide a valid measurement.
+    /// Visual components should reflect this information by blanking the display or some other appropriate means.
+    public static let nan = MedFloat16(bitPattern: 0x07FF)
+
+    public static let infinity = MedFloat16(bitPattern: 0x07FE)
+
+    static let negativeInfinity = MedFloat16(bitPattern: 0x0802)
+
+    /// Value cannot be represented with the available range or resolution.
+    ///
+    /// This situation could result from an overflow or underflow situation.
+    public static let nres = MedFloat16(bitPattern: 0x0800)
+
+    static let reserved0 = MedFloat16(bitPattern: 0x0801)
+
+    /// The radix of the floating point number.
+    public static let radix: Int = 10
+
+
+    /// A Boolean value indicating whether the instance is NaN ("not a number").
+    ///
+    /// Because NaN is not equal to any value, including NaN, use this property
+    /// instead of the equal-to operator (`==`) or not-equal-to operator (`!=`)
+    /// to test whether a value is or is not NaN.
+    public var isNaN: Bool {
+        bitPattern == MedFloat16.nan.bitPattern
+    }
+
+    public var isZero: Bool {
+        mantissa == 0
+    }
+
+    /// A Boolean value indicating whether the instance is nRes ("not at this resolution").
+    ///
+    /// Because nRes is not equal to any value, including nRes, use this property
+    /// instead of the equal-to operator (`==`) or not-equal-to operator (`!=`)
+    /// to test whether a value is or is not nRes.
+    public var isNRes: Bool {
+        bitPattern == MedFloat16.nres.bitPattern
+    }
+
+    /// Reserved special value.
+    var isReserved0: Bool {
+        bitPattern == MedFloat16.reserved0.bitPattern
+    }
+
+    /// A Boolean value indicating whether this instance is finite.
+    ///
+    /// All values other than NaN, nRes and infinity are considered finite, whether
+    /// normal or subnormal.  For NaN and nRes, both `isFinite` and ``isInfinite`` are false.
+    public var isFinite: Bool {
+        !isNaN && !isNRes && !isInfinite
+    }
+
+    /// A Boolean value indicating whether the instance is infinite.
+    ///
+    /// For NaN and nRes, both ``isFinite`` and `isInfinite` are false.
+    public var isInfinite: Bool {
+        bitPattern == MedFloat16.infinity.bitPattern
+            || bitPattern == MedFloat16.negativeInfinity.bitPattern
+    }
+
+
+    /// The sign of the floating-point value.
+    ///
+    /// The sign is `minus` if the mantissa has a negative value and `plus` otherwise.
+    public var sign: FloatingPointSign {
+        if mantissa < 0 {
+            .minus
+        } else {
+            .plus
+        }
+    }
+}
+
+
+extension MedFloat16: Sendable {}
+
+
+extension MedFloat16: Equatable {
+    public static func == (lhs: MedFloat16, rhs: MedFloat16) -> Bool {
+        switch (lhs.bitPattern, rhs.bitPattern) {
+        case (MedFloat16.nan.bitPattern, _),
+            (MedFloat16.nres.bitPattern, _),
+            (MedFloat16.reserved0.bitPattern, _),
+            (_, MedFloat16.nan.bitPattern),
+            (_, MedFloat16.nres.bitPattern),
+            (_, MedFloat16.reserved0.bitPattern):
+            return false // any nan-like is never equal
+        default:
+            return lhs.bitPattern == rhs.bitPattern
+                || (lhs.isZero && rhs.isZero) // any value with zero mantissa is zero
+        }
+    }
+}
+
+
+
+extension MedFloat16: CustomStringConvertible {
+    public var description: String {
+        if isNaN || isReserved0 {
+            return "nan"
+        } else if isNRes {
+            return "nres"
+        } else if bitPattern == MedFloat16.infinity.bitPattern {
+            return "inf"
+        } else if bitPattern == MedFloat16.negativeInfinity.bitPattern {
+            return "-inf"
+        } else if isZero {
+            return "0.0" // map all zeros to same representation
+        }
+
+        let exponent = exponent
+        let mantissa = mantissa
+
+        var baseDescription = mantissa.description // TODO: sign??
+
+        if exponent > 0 {
+            baseDescription
+                .append(String(repeating: "0", count: Int(exponent)))
+
+            baseDescription
+                .append(".0")
+        } else if exponent == 0 {
+            baseDescription
+                .append(".0")
+        } else { // exponent < 0
+            let digitCount = baseDescription.count - (sign == .minus ? 1 : 0)
+
+            if -exponent < digitCount {
+                let dotIndex = baseDescription.index(baseDescription.endIndex, offsetBy: Int(exponent))
+
+                baseDescription.insert(".", at: dotIndex)
+            } else {
+                let insertionIndex = sign == .minus
+                    ? baseDescription.index(after: baseDescription.startIndex) // skipping the "-"
+                    : baseDescription.startIndex
+
+                let zeroPrefix = String(repeating: "0", count: Int(-exponent) - digitCount)
+                baseDescription.insert(contentsOf: zeroPrefix, at: insertionIndex)
+
+                baseDescription.insert(contentsOf: "0.", at: insertionIndex)
+            }
+        }
+
+        return baseDescription
+    }
+}
+
+
+
+extension MedFloat16: CustomDebugStringConvertible {
+    public var debugDescription: String {
+        description
+    }
+}
+// TODO: can we provide custom number formatting?
+
+// TODO: integer literal?
+
+
+// TODO: comparable?
+
+// TODO: AdditiveArithmetic? SignedNumeric protocol (aka. Numeric)
+/*
+ extension MedFloat16: AdditiveArithmetic {
+ public static let zero = MedFloat16(bitPattern: 0) // TODO: is this true?
+
+ public static func + (lhs: MedFloat16, rhs: MedFloat16) -> MedFloat16 {
+ <#code#>
+ }
+
+ public static func - (lhs: MedFloat16, rhs: MedFloat16) -> MedFloat16 {
+ <#code#>
+ }
+ }
+ */
+
+
+
+extension MedFloat16: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let bitPattern = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.init(bitPattern: bitPattern)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        bitPattern.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+
+extension MedFloat16 {
+    fileprivate static let maxInt4 = Int8(bitPattern: 0x7)
+    fileprivate static let minInt4 = Int8(bitPattern: 0xF8)
+
+    fileprivate static let maxInt12 = Int16(bitPattern: 0x7FF)
+    fileprivate static let minInt12 = Int16(bitPattern: 0xF800)
+}

--- a/Sources/BluetoothServices/TestingSupport/EventLog.swift
+++ b/Sources/BluetoothServices/TestingSupport/EventLog.swift
@@ -17,7 +17,7 @@ import SpeziBluetooth
 ///
 /// Those events always imply to happen on characteristics of the `TestService`.
 @_spi(TestingSupport)
-public enum EventLog: Sendable {
+public enum EventLog {
     /// No event happened yet.
     case none
     /// Central subscribed to the notifications of the given characteristic.
@@ -32,7 +32,7 @@ public enum EventLog: Sendable {
 
 
 @_spi(TestingSupport)
-extension EventLog: Equatable {}
+extension EventLog: Hashable, Sendable {}
 
 
 @_spi(TestingSupport)

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -39,6 +39,24 @@ final class BluetoothServicesTests: XCTestCase {
         try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .celsius, timeStamp: time))
     }
 
+    func testBloodPressureMeasurement() throws {
+        let time = DateTime(hours: 13, minutes: 12, seconds: 12)
+
+        try testIdentity(from: BloodPressureMeasurement(systolic: 120.5, diastolic: 80.5, meanArterialPressure: 60, unit: .mmHg))
+        try testIdentity(from: BloodPressureMeasurement(systolic: 120.5, diastolic: 80.5, meanArterialPressure: 60, unit: .kPa))
+
+        try testIdentity(from: BloodPressureMeasurement(
+            systolic: 120.5,
+            diastolic: 80.5,
+            meanArterialPressure: 60,
+            unit: .mmHg,
+            timeStamp: time,
+            pulseRate: 54,
+            userId: 0x67,
+            measurementStatus: [.irregularPulse, .bodyMovementDetected]
+        ))
+    }
+
     func testTemperatureType() throws {
         for type in TemperatureType.allCases {
             try testIdentity(from: type)

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -57,6 +57,46 @@ final class BluetoothServicesTests: XCTestCase {
         ))
     }
 
+    func testIntermediateCuffPressure() throws {
+        let time = DateTime(hours: 13, minutes: 12, seconds: 12)
+
+        try testIdentity(from: IntermediateCuffPressure(currentCuffPressure: 56, unit: .mmHg))
+        try testIdentity(from: IntermediateCuffPressure(currentCuffPressure: 56, unit: .kPa))
+
+        try testIdentity(from: IntermediateCuffPressure(
+            currentCuffPressure: 56,
+            unit: .mmHg,
+            timeStamp: time,
+            pulseRate: 54,
+            userId: 0x67,
+            measurementStatus: [.irregularPulse, .bodyMovementDetected]
+        ))
+    }
+
+    func testBloodPressureFeature() throws {
+        let features: BloodPressureFeature = [
+            .bodyMovementDetectionSupported,
+            .cuffFitDetectionSupported,
+            .irregularPulseDetectionSupported,
+            .pulseRateRangeDetectionSupported,
+            .measurementPositionDetectionSupported,
+            .multipleBondsSupported,
+            .e2eCrcSupported,
+            .userDataServiceSupported,
+            .userFacingTimeSupported
+        ]
+
+        XCTAssertTrue(features.contains(.bodyMovementDetectionSupported))
+        XCTAssertTrue(features.contains(.cuffFitDetectionSupported))
+        XCTAssertTrue(features.contains(.irregularPulseDetectionSupported))
+        XCTAssertTrue(features.contains(.pulseRateRangeDetectionSupported))
+        XCTAssertTrue(features.contains(.measurementPositionDetectionSupported))
+        XCTAssertTrue(features.contains(.multipleBondsSupported))
+        XCTAssertTrue(features.contains(.e2eCrcSupported))
+        XCTAssertTrue(features.contains(.userDataServiceSupported))
+        XCTAssertTrue(features.contains(.userFacingTimeSupported))
+    }
+
     func testTemperatureType() throws {
         for type in TemperatureType.allCases {
             try testIdentity(from: type)

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -95,6 +95,13 @@ final class BluetoothServicesTests: XCTestCase {
         XCTAssertTrue(features.contains(.e2eCrcSupported))
         XCTAssertTrue(features.contains(.userDataServiceSupported))
         XCTAssertTrue(features.contains(.userFacingTimeSupported))
+
+        let features2: BloodPressureFeature = [BloodPressureFeature.bodyMovementDetectionSupported, .irregularPulseDetectionSupported]
+        let features3: BloodPressureFeature = [BloodPressureFeature.bodyMovementDetectionSupported, .userFacingTimeSupported]
+
+        try testIdentity(from: features)
+        try testIdentity(from: features2)
+        try testIdentity(from: features3)
     }
 
     func testTemperatureType() throws {

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -28,15 +28,15 @@ final class BluetoothServicesTests: XCTestCase {
     }
 
     func testTemperatureMeasurement() throws {
-        let data = try XCTUnwrap(Data(hex: "0xAFAFAFAF")) // 4 bytes for the medfloat
+        let data: UInt32 = 0xAFAFAFAF // 4 bytes for the medfloat
         let time = DateTime(hours: 13, minutes: 12, seconds: 12)
 
-        try testIdentity(from: TemperatureMeasurement(value: .celsius(data)))
-        try testIdentity(from: TemperatureMeasurement(value: .fahrenheit(data)))
+        try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .celsius))
+        try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .fahrenheit))
 
-        try testIdentity(from: TemperatureMeasurement(value: .celsius(data), timeStamp: time, temperatureType: .ear))
-        try testIdentity(from: TemperatureMeasurement(value: .celsius(data), temperatureType: .ear))
-        try testIdentity(from: TemperatureMeasurement(value: .celsius(data), timeStamp: time))
+        try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .celsius, timeStamp: time, temperatureType: .ear))
+        try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .celsius, temperatureType: .ear))
+        try testIdentity(from: TemperatureMeasurement(temperature: data, unit: .celsius, timeStamp: time))
     }
 
     func testTemperatureType() throws {

--- a/Tests/SpeziBluetoothTests/MedFloatTests.swift
+++ b/Tests/SpeziBluetoothTests/MedFloatTests.swift
@@ -36,7 +36,7 @@ final class MedFloatTests: XCTestCase {
         XCTAssertEqual(MedFloat16(-0.0000012), MedFloat16(exponent: -7, mantissa: -12))
     }
 
-    func testBasicRepresentations() {
+    func testBasicRepresentations() { // swiftlint:disable:this function_body_length
         let largeFloat = MedFloat16(exponent: 3, mantissa: 123)
         let smallFloat = MedFloat16(exponent: -2, mantissa: 1234)
         let smallSmallFloat = MedFloat16(exponent: -7, mantissa: 12)

--- a/Tests/SpeziBluetoothTests/MedFloatTests.swift
+++ b/Tests/SpeziBluetoothTests/MedFloatTests.swift
@@ -1,0 +1,95 @@
+//
+// This source file is part of the Stanford Spezi open source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+@testable import BluetoothServices
+import XCTest
+
+
+final class MedFloatTests: XCTestCase {
+    func testSpecialValues() {
+        XCTAssertTrue(MedFloat16.nan.double.isNaN)
+        XCTAssertTrue(MedFloat16.nres.double.isNaN)
+        XCTAssertTrue(MedFloat16.reserved0.double.isNaN)
+        XCTAssertEqual(MedFloat16.infinity.double, .infinity)
+        XCTAssertEqual(MedFloat16.negativeInfinity.double, -Double.infinity)
+
+        XCTAssertTrue(MedFloat16.nan.float.isNaN)
+        XCTAssertTrue(MedFloat16.nres.float.isNaN)
+        XCTAssertTrue(MedFloat16.reserved0.float.isNaN)
+        XCTAssertEqual(MedFloat16.infinity.float, .infinity)
+        XCTAssertEqual(MedFloat16.negativeInfinity.float, -Float.infinity)
+
+        print(Int64.max)
+        print(Float(integerLiteral: .max).description)
+        print(Float(integerLiteral: .max).debugDescription)
+        print(Float(integerLiteral: .max).bitPattern)
+        print(Double(integerLiteral: .max).description)
+        print(Double(integerLiteral: .max).debugDescription)
+        print(Double(integerLiteral: .max).bitPattern)
+    }
+
+    func testBasicRepresentations() {
+        let largeFloat = MedFloat16(exponent: 3, mantissa: 123)
+        let smallFloat = MedFloat16(exponent: -2, mantissa: 1234)
+        let smallSmallFloat = MedFloat16(exponent: -7, mantissa: 12)
+
+        let zeroExponentFloat = MedFloat16(exponent: 0, mantissa: 1234)
+
+        let negLargeFloat = MedFloat16(exponent: 3, mantissa: -123)
+        let negSmallFloat = MedFloat16(exponent: -2, mantissa: -1234)
+        let negSmallSmallFloat = MedFloat16(exponent: -7, mantissa: -12)
+
+        XCTAssertEqual(largeFloat.exponent, 3)
+        XCTAssertEqual(largeFloat.mantissa, 123)
+        XCTAssertEqual(smallFloat.exponent, -2)
+        XCTAssertEqual(smallFloat.mantissa, 1234)
+        XCTAssertEqual(smallSmallFloat.exponent, -7)
+        XCTAssertEqual(smallSmallFloat.mantissa, 12)
+
+        XCTAssertEqual(zeroExponentFloat.exponent, 0)
+        XCTAssertEqual(zeroExponentFloat.mantissa, 1234)
+
+        XCTAssertEqual(negLargeFloat.exponent, 3)
+        XCTAssertEqual(negLargeFloat.mantissa, -123)
+        XCTAssertEqual(negSmallFloat.exponent, -2)
+        XCTAssertEqual(negSmallFloat.mantissa, -1234)
+        XCTAssertEqual(negSmallSmallFloat.exponent, -7)
+        XCTAssertEqual(negSmallSmallFloat.mantissa, -12)
+
+        XCTAssertTrue(largeFloat.isFinite)
+        XCTAssertTrue(smallFloat.isFinite)
+        XCTAssertTrue(smallSmallFloat.isFinite)
+        XCTAssertTrue(negLargeFloat.isFinite)
+        XCTAssertTrue(negSmallFloat.isFinite)
+        XCTAssertTrue(negSmallSmallFloat.isFinite)
+
+        XCTAssertEqual(largeFloat.double, 123000.0)
+        XCTAssertEqual(smallFloat.double, 12.34)
+        XCTAssertEqual(smallSmallFloat.double, 0.0000012)
+        XCTAssertEqual(zeroExponentFloat.double, 1234.0)
+        XCTAssertEqual(negLargeFloat.double, -123000.0)
+        XCTAssertEqual(negSmallFloat.double, -12.34)
+        XCTAssertEqual(negSmallSmallFloat.double, -0.0000012)
+
+
+        XCTAssertEqual(MedFloat16.nan.description, "nan")
+        XCTAssertEqual(MedFloat16.reserved0.description, "nan")
+        XCTAssertEqual(MedFloat16.nres.description, "nres")
+        XCTAssertEqual(MedFloat16.zero.description, "0.0")
+        XCTAssertEqual(MedFloat16.infinity.description, "inf")
+        XCTAssertEqual(MedFloat16.negativeInfinity.description, "-inf")
+
+        XCTAssertEqual(largeFloat.description, "123000.0")
+        XCTAssertEqual(smallFloat.description, "12.34")
+        XCTAssertEqual(smallSmallFloat.description, "0.0000012")
+        XCTAssertEqual(zeroExponentFloat.description, "1234.0")
+        XCTAssertEqual(negLargeFloat.description, "-123000.0")
+        XCTAssertEqual(negSmallFloat.description, "-12.34")
+        XCTAssertEqual(negSmallSmallFloat.description, "-0.0000012")
+    }
+}

--- a/Tests/SpeziBluetoothTests/MedFloatTests.swift
+++ b/Tests/SpeziBluetoothTests/MedFloatTests.swift
@@ -94,6 +94,8 @@ final class MedFloatTests: XCTestCase {
         XCTAssertEqual(negLargeFloat.description, "-123000.0")
         XCTAssertEqual(negSmallFloat.description, "-12.34")
         XCTAssertEqual(negSmallSmallFloat.description, "-0.0000012")
+        XCTAssertEqual(MedFloat16(127).description, "127.0")
+        XCTAssertEqual(MedFloat16(12).description, "12.0")
     }
 
     func testEquality() {
@@ -119,5 +121,74 @@ final class MedFloatTests: XCTestCase {
 
         XCTAssertEqual(float3, float4)
         XCTAssertEqual(float3.description, float4.description)
+    }
+
+    // TODO: test int literal init + float literal
+    func testLiteralInits() {
+        XCTAssertEqual(MedFloat16(150000000000), .infinity)
+        XCTAssertEqual(MedFloat16(-150000000000), .negativeInfinity)
+
+        print(Float(sign: .plus, exponent: 267, significand: 0.6))
+        print(MedFloat16(150000000000).description)
+        print(MedFloat16(150000000000).debugDescription)
+    }
+
+    func testExactlyConversion() {
+        XCTAssertEqual(MedFloat16(exactly: UInt8.max), 255)
+        XCTAssertEqual(MedFloat16(exactly: Int8.max), 127)
+        XCTAssertEqual(MedFloat16(exactly: 12400), 12400)
+
+        XCTAssertNil(MedFloat16(exactly: Int16.max))
+        XCTAssertNil(MedFloat16(exactly: UInt16.max))
+        XCTAssertNil(MedFloat16(exactly: Int32.max))
+        XCTAssertNil(MedFloat16(exactly: UInt32.max))
+        XCTAssertNil(MedFloat16(exactly: Int64.max))
+        XCTAssertNil(MedFloat16(exactly: UInt64.max))
+    }
+
+    func testOrdering() {
+        // TODO: test ordering
+    }
+
+    func testAddition() { // TODO: add tests
+        XCTAssertTrue((MedFloat16.infinity + .negativeInfinity).isNaN)
+        XCTAssertTrue((MedFloat16.negativeInfinity + .infinity).isNaN)
+
+        XCTAssertTrue((MedFloat16.nan + .nan).isNaN)
+        XCTAssertTrue((MedFloat16.nres + .nres).isNaN)
+        XCTAssertTrue((MedFloat16.nan + .nres).isNaN)
+        XCTAssertTrue((MedFloat16.nres + .nan).isNaN)
+        XCTAssertTrue((MedFloat16.reserved0 + .nan).isNaN)
+        XCTAssertTrue((MedFloat16.nan + .reserved0).isNaN)
+        XCTAssertTrue((MedFloat16.nres + .reserved0).isNaN)
+        XCTAssertTrue((MedFloat16.reserved0 + .nres).isNaN)
+
+        XCTAssertEqual(MedFloat16.infinity + .infinity, .infinity)
+        XCTAssertEqual(MedFloat16.infinity + 12, .infinity)
+        XCTAssertEqual(MedFloat16.infinity + -12, .infinity)
+
+        XCTAssertEqual(MedFloat16.negativeInfinity + .negativeInfinity, .negativeInfinity)
+        XCTAssertEqual(MedFloat16.negativeInfinity + 12, .negativeInfinity)
+        XCTAssertEqual(MedFloat16.negativeInfinity + -12, .negativeInfinity)
+
+
+        XCTAssertEqual(MedFloat16(15) + 12, 27)
+        XCTAssertEqual(MedFloat16(15000000000) + 12000000000, .infinity)
+        XCTAssertEqual(MedFloat16(1500000000) + 1200000000, 2700000000)
+        XCTAssertEqual(MedFloat16(15000000) + 120000, 15120000)
+    }
+
+    func testMagnitude() {
+        XCTAssertTrue(MedFloat16.nan.magnitude.isNaN)
+        XCTAssertTrue(MedFloat16.nres.magnitude.isNRes)
+        XCTAssertTrue(MedFloat16.reserved0.magnitude.isReserved0)
+
+        XCTAssertEqual(MedFloat16.infinity.magnitude, .infinity)
+        XCTAssertEqual(MedFloat16.negativeInfinity.magnitude, .infinity)
+
+        XCTAssertEqual(MedFloat16.zero.magnitude, .zero)
+
+        XCTAssertEqual(MedFloat16(12.5).magnitude, 12.5)
+        XCTAssertEqual(MedFloat16(-12.5).magnitude, 12.5)
     }
 }

--- a/Tests/SpeziBluetoothTests/MedFloatTests.swift
+++ b/Tests/SpeziBluetoothTests/MedFloatTests.swift
@@ -17,20 +17,23 @@ final class MedFloatTests: XCTestCase {
         XCTAssertTrue(MedFloat16.reserved0.double.isNaN)
         XCTAssertEqual(MedFloat16.infinity.double, .infinity)
         XCTAssertEqual(MedFloat16.negativeInfinity.double, -Double.infinity)
+    }
 
-        XCTAssertTrue(MedFloat16.nan.float.isNaN)
-        XCTAssertTrue(MedFloat16.nres.float.isNaN)
-        XCTAssertTrue(MedFloat16.reserved0.float.isNaN)
-        XCTAssertEqual(MedFloat16.infinity.float, .infinity)
-        XCTAssertEqual(MedFloat16.negativeInfinity.float, -Float.infinity)
+    func testDoubleConversion() {
+        XCTAssertTrue(MedFloat16(.nan).isNaN)
+        XCTAssertTrue(MedFloat16(.zero).isZero)
+        XCTAssertEqual(MedFloat16(.infinity), .infinity)
+        XCTAssertEqual(MedFloat16(-.infinity), .negativeInfinity)
 
-        print(Int64.max)
-        print(Float(integerLiteral: .max).description)
-        print(Float(integerLiteral: .max).debugDescription)
-        print(Float(integerLiteral: .max).bitPattern)
-        print(Double(integerLiteral: .max).description)
-        print(Double(integerLiteral: .max).debugDescription)
-        print(Double(integerLiteral: .max).bitPattern)
+        XCTAssertEqual(MedFloat16(123000.0), MedFloat16(exponent: 3, mantissa: 123))
+        XCTAssertEqual(MedFloat16(12.34), MedFloat16(exponent: -2, mantissa: 1234))
+        XCTAssertEqual(MedFloat16(0.0000012), MedFloat16(exponent: -7, mantissa: 12))
+
+        XCTAssertEqual(MedFloat16(1234.0), MedFloat16(exponent: 0, mantissa: 1234))
+
+        XCTAssertEqual(MedFloat16(-123000.0), MedFloat16(exponent: 3, mantissa: -123))
+        XCTAssertEqual(MedFloat16(-12.34), MedFloat16(exponent: -2, mantissa: -1234))
+        XCTAssertEqual(MedFloat16(-0.0000012), MedFloat16(exponent: -7, mantissa: -12))
     }
 
     func testBasicRepresentations() {
@@ -44,22 +47,22 @@ final class MedFloatTests: XCTestCase {
         let negSmallFloat = MedFloat16(exponent: -2, mantissa: -1234)
         let negSmallSmallFloat = MedFloat16(exponent: -7, mantissa: -12)
 
-        XCTAssertEqual(largeFloat.exponent, 3)
-        XCTAssertEqual(largeFloat.mantissa, 123)
+        XCTAssertEqual(largeFloat.exponent, 2)
+        XCTAssertEqual(largeFloat.mantissa, 1230)
         XCTAssertEqual(smallFloat.exponent, -2)
         XCTAssertEqual(smallFloat.mantissa, 1234)
-        XCTAssertEqual(smallSmallFloat.exponent, -7)
-        XCTAssertEqual(smallSmallFloat.mantissa, 12)
+        XCTAssertEqual(smallSmallFloat.exponent, -8)
+        XCTAssertEqual(smallSmallFloat.mantissa, 120)
 
         XCTAssertEqual(zeroExponentFloat.exponent, 0)
         XCTAssertEqual(zeroExponentFloat.mantissa, 1234)
 
-        XCTAssertEqual(negLargeFloat.exponent, 3)
-        XCTAssertEqual(negLargeFloat.mantissa, -123)
+        XCTAssertEqual(negLargeFloat.exponent, 2)
+        XCTAssertEqual(negLargeFloat.mantissa, -1230)
         XCTAssertEqual(negSmallFloat.exponent, -2)
         XCTAssertEqual(negSmallFloat.mantissa, -1234)
-        XCTAssertEqual(negSmallSmallFloat.exponent, -7)
-        XCTAssertEqual(negSmallSmallFloat.mantissa, -12)
+        XCTAssertEqual(negSmallSmallFloat.exponent, -8)
+        XCTAssertEqual(negSmallSmallFloat.mantissa, -120)
 
         XCTAssertTrue(largeFloat.isFinite)
         XCTAssertTrue(smallFloat.isFinite)
@@ -91,5 +94,30 @@ final class MedFloatTests: XCTestCase {
         XCTAssertEqual(negLargeFloat.description, "-123000.0")
         XCTAssertEqual(negSmallFloat.description, "-12.34")
         XCTAssertEqual(negSmallSmallFloat.description, "-0.0000012")
+    }
+
+    func testEquality() {
+        XCTAssertNotEqual(MedFloat16.nan, .nan)
+        XCTAssertNotEqual(MedFloat16.nan, .nres)
+        XCTAssertNotEqual(MedFloat16.nan, .infinity)
+        XCTAssertNotEqual(MedFloat16.nan, MedFloat16(123))
+        XCTAssertNotEqual(MedFloat16.nres, .nres)
+
+
+        let float0 = MedFloat16(exponent: -1, mantissa: 130)
+        let float1 = MedFloat16(exponent: 0, mantissa: 13)
+        let float2 = MedFloat16(exponent: -2, mantissa: 1300)
+
+        XCTAssertEqual(float0, float1)
+        XCTAssertEqual(float0, float2)
+        XCTAssertEqual(float1, float2)
+        XCTAssertEqual(float0.description, float1.description)
+        XCTAssertEqual(float1.description, float2.description)
+
+        let float3 = MedFloat16(exponent: 1, mantissa: 10)
+        let float4 = MedFloat16(exponent: 0, mantissa: 100)
+
+        XCTAssertEqual(float3, float4)
+        XCTAssertEqual(float3.description, float4.description)
     }
 }

--- a/Tests/SpeziBluetoothTests/MedFloatTests.swift
+++ b/Tests/SpeziBluetoothTests/MedFloatTests.swift
@@ -94,6 +94,7 @@ final class MedFloatTests: XCTestCase {
         XCTAssertEqual(negLargeFloat.description, "-123000.0")
         XCTAssertEqual(negSmallFloat.description, "-12.34")
         XCTAssertEqual(negSmallSmallFloat.description, "-0.0000012")
+
         XCTAssertEqual(MedFloat16(127).description, "127.0")
         XCTAssertEqual(MedFloat16(12).description, "12.0")
     }


### PR DESCRIPTION
# Implement Blood Pressure Measurement characteristics and start MedFloat16

## :recycle: Current situation & Problem
This PR implements basic support for the Bluetooth Blood Pressure Service. Most importantly, we add a MedFloat16 implementation (according to IEEE 11073-20601). The type fully conforms to Swift's [`SignedNumeric`](https://developer.apple.com/documentation/swift/signednumeric) protocol, adding support for basic arithmetic operations, equatablility, hashability, comparability and support for integer and float literal initializers. Of course, we also support conversion from and to bitPattern representation.

For the Blood Pressure Service the PR currently only implements the essential, mandatory characteristics for the service. There currently is no pre-implemented service. We currently don't support the Extended Blood Pressure Service (might follow if it is supported by the Omron devices. Didn't have the devices with me to verify).

## :gear: Release Notes 
* Added the `BloodPressureMeasurement` characteristic
* Added the `IntermediateCuffPressure` characteristic
* Added the `BloodPressureFeature` characteristic
* Added a `MedFloat16` implementation

## :books: Documentation
New symbols were fully documented.

## :white_check_mark: Testing
Extensive unit testing was added for all new symbols.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
