### PR TITLE
Adding support for for weight scale service

### DIFF
--- a/README.md
+++ b/README.md
@@ -115,7 +115,7 @@ class MyDevice: BluetoothDevice {
     @DeviceAction(\.disconnect)
     var disconnect
 
-    init() {} // required initializer
+    required init() {}
 }
 ```
 

--- a/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
@@ -33,14 +33,19 @@ which natively integrates with SpeziBluetooth-defined services.
 - ``PnPID``
 - ``VendorIDSource``
 
+### Blood Pressure
+
+- ``BloodPressureMeasurement``
+- ``BloodPressureFeature``
+- ``IntermediateCuffPressure``
+
 ### Temperature Measurement
 
 - ``TemperatureMeasurement``
 - ``TemperatureType``
 - ``MeasurementInterval``
 
-### Blood Pressure
+### Weight Measurement
 
-- ``BloodPressureMeasurement``
-- ``BloodPressureFeature``
-- ``IntermediateCuffPressure``
+- ``WeightMeasurement``
+- ``WeightScaleFeature``

--- a/Sources/BluetoothServices/BluetoothServices.docc/Services.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Services.md
@@ -21,7 +21,10 @@ Below is a list of reusable Bluetooth service implementations of standardized Bl
 ### Core Services
 
 - ``DeviceInformationService``
+- ``BatteryService``
 
 ### Health Domain
 
+- ``BloodPressureService``
 - ``HealthThermometerService``
+- ``WeightScaleService``

--- a/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
@@ -11,6 +11,9 @@ import Foundation
 import NIOCore
 
 
+/// Features of a weight scale.
+///
+/// Refer to GATT Specification Supplement, 3.30 Blood Pressure Feature.
 public struct BloodPressureFeature: OptionSet {
     /// Indicate if body movement detection is supported.
     ///

--- a/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
@@ -1,0 +1,213 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// A weight measurement.
+///
+/// Refer to GATT Specification Supplement, 3.252 Weight Measurement.
+public struct WeightMeasurement {
+    fileprivate struct Flags: OptionSet {
+        let rawValue: UInt8
+
+        static let isImperialUnit = Flags(rawValue: 1 << 0)
+        static let timeStampPresent = Flags(rawValue: 1 << 1)
+        static let userIdPresent = Flags(rawValue: 1 << 2)
+        static let bmiAndHeightPresent = Flags(rawValue: 1 << 3)
+
+        init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// Units for a weight measurement.
+    public enum Unit {
+        /// SI units (Weight and Mass in units of kilogram (kg) and Height in units of meter).
+        case si
+        /// Imperial units. (Weight and Mass in units of pound (lb) and Height in units of inch (in)).
+        case imperial
+    }
+
+    /// Additional metadata information for a weight measurement.
+    public struct AdditionalInfo {
+        /// The BMI in units of 0.1 kg/m2.
+        public let bmi: UInt16
+        /// The height.
+        ///
+        /// The unit of this value is defined by the ``WeightMeasurement/unit-swift.property`` property.
+        /// The value has a resolution of `0.001` in meters and a resolution of `0.1` in inches.
+        public let height: UInt16 // TODO: automatic float conversion?
+
+
+        // TODO: app code docs!
+        public init(bmi: UInt16, height: UInt16) {
+            self.bmi = bmi
+            self.height = height
+        }
+    }
+
+    /// The weight measurement.
+    ///
+    /// The unit of this value is defined by the ``unit-swift.property`` property.
+    /// The value has a resolution of `0.005` in kg and a resolution of `0.01` in pounds.
+    public let weight: UInt16 // TODO: automatic float conversion?
+    /// The unit of a weight measurement.
+    public let unit: Unit
+
+    /// The timestamp of the measurement.
+    public let timeStamp: DateTime?
+    /// The associated user of the weight measurement.
+    ///
+    /// This value can be used to differentiate users if the device supports multiple users.
+    /// - Note: The special value of `0xFF` (`UInt8.max`) is used to represent an unknown user.
+    ///
+    /// The values are left to the implementation but should be unique per device.
+    public let userId: UInt8?
+
+
+    /// Additional information like BMI and Height.
+    public let additionalInfo: AdditionalInfo?
+
+
+    // TODO: app code docs
+    public init(weight: UInt16, unit: Unit, timeStamp: DateTime? = nil, userId: UInt8? = nil, additionalInfo: AdditionalInfo? = nil) {
+        self.weight = weight
+        self.unit = unit
+        self.timeStamp = timeStamp
+        self.userId = userId
+        self.additionalInfo = additionalInfo
+    }
+}
+
+
+extension WeightMeasurement {
+    public func weight(of resolution: WeightScaleFeature.WeightResolution) -> Double {
+        Double(weight) * resolution.magnitude(in: unit)
+    }
+
+
+    public func height(of resolution: WeightScaleFeature.HeightResolution) -> Double? {
+        (additionalInfo?.height)
+            .map(Double.init)
+            .map { $0 * resolution.magnitude(in: unit) }
+    }
+}
+
+
+extension WeightMeasurement.Unit: Hashable, Sendable {}
+
+
+extension WeightMeasurement.AdditionalInfo: Hashable, Sendable {}
+
+
+extension WeightMeasurement: Hashable, Sendable {}
+
+
+extension WeightMeasurement.Flags: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+extension WeightMeasurement.AdditionalInfo: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let bmi = UInt16(from: &byteBuffer, preferredEndianness: endianness),
+              let height = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(bmi: bmi, height: height)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        bmi.encode(to: &byteBuffer, preferredEndianness: endianness)
+        height.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+extension WeightMeasurement: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
+              let weight = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.weight = weight
+
+        if flags.contains(.isImperialUnit) {
+            self.unit = .imperial
+        } else {
+            self.unit = .si
+        }
+
+        if flags.contains(.timeStampPresent) {
+            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.timeStamp = timeStamp
+        } else {
+            self.timeStamp = nil
+        }
+
+        if flags.contains(.userIdPresent) {
+            guard let userId = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.userId = userId
+        } else {
+            self.userId = nil
+        }
+
+        if flags.contains(.bmiAndHeightPresent) {
+            guard let additionalInfo = AdditionalInfo(from: &byteBuffer, preferredEndianness: endianness) else {
+                return nil
+            }
+            self.additionalInfo = additionalInfo
+        } else {
+            self.additionalInfo = nil
+        }
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        var flags: Flags = []
+
+        // write empty flags field for now to move writer index
+        let flagsIndex = byteBuffer.writerIndex
+        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
+
+        weight.encode(to: &byteBuffer, preferredEndianness: endianness)
+
+        if let timeStamp {
+            flags.insert(.timeStampPresent)
+            timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        if let userId {
+            flags.insert(.userIdPresent)
+            userId.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        if let additionalInfo {
+            flags.insert(.bmiAndHeightPresent)
+            additionalInfo.encode(to: &byteBuffer, preferredEndianness: endianness)
+        }
+
+        byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
@@ -31,23 +31,31 @@ public struct WeightMeasurement {
     /// Units for a weight measurement.
     public enum Unit {
         /// SI units (Weight and Mass in units of kilogram (kg) and Height in units of meter).
-        case si
+        case si // swiftlint:disable:this identifier_name
         /// Imperial units. (Weight and Mass in units of pound (lb) and Height in units of inch (in)).
         case imperial
     }
 
     /// Additional metadata information for a weight measurement.
     public struct AdditionalInfo {
-        /// The BMI in units of 0.1 kg/m2.
+        /// The BMI.
+        ///
+        /// The value is in units of 0.1 kg/m2.
         public let bmi: UInt16
         /// The height.
         ///
         /// The unit of this value is defined by the ``WeightMeasurement/unit-swift.property`` property.
-        /// The value has a resolution of `0.001` in meters and a resolution of `0.1` in inches.
-        public let height: UInt16 // TODO: automatic float conversion?
+        ///
+        /// The resolution of this value is defined by the ``WeightScaleFeature/heightResolution-swift.property`` property.
+        /// Otherwise, if nto specified the value has a resolution of `0.001` in meters and a resolution of `0.1` in inches.
+        public let height: UInt16
 
 
-        // TODO: app code docs!
+        /// Initialize new additional information for a weight measurement.
+        /// - Parameters:
+        ///   - bmi: The BMI in units of 0.1 kg/m2.
+        ///   - height: The height. Unit is defined by ``WeightMeasurement/unit-swift.property`` and resolution by
+        ///     ``WeightScaleFeature/heightResolution-swift.property`` or in `0.001` meters and `0.1` inches if not specified.
         public init(bmi: UInt16, height: UInt16) {
             self.bmi = bmi
             self.height = height
@@ -57,8 +65,9 @@ public struct WeightMeasurement {
     /// The weight measurement.
     ///
     /// The unit of this value is defined by the ``unit-swift.property`` property.
-    /// The value has a resolution of `0.005` in kg and a resolution of `0.01` in pounds.
-    public let weight: UInt16 // TODO: automatic float conversion?
+    /// The value has a resolution as defined by ``WeightMeasurement/unit-swift.property`` or, otheriwse,
+    /// of `0.005` in kg and a resolution of `0.01` in pounds.
+    public let weight: UInt16
     /// The unit of a weight measurement.
     public let unit: Unit
 
@@ -77,7 +86,15 @@ public struct WeightMeasurement {
     public let additionalInfo: AdditionalInfo?
 
 
-    // TODO: app code docs
+    /// Create a new weight measurement.
+    ///
+    /// - Parameters:
+    ///   - weight: The weight in resolution as defined by ``WeightScaleFeature/weightResolution-swift.property``
+    ///     or `0.005` in kg and a resolution of `0.01` in pounds.
+    ///   - unit: The units used for weight and height.
+    ///   - timeStamp: The timestamp of the measurement.
+    ///   - userId: The associated user of the weight measurement.
+    ///   - additionalInfo: Additional information collected by a weight scale like BMI and height.
     public init(weight: UInt16, unit: Unit, timeStamp: DateTime? = nil, userId: UInt8? = nil, additionalInfo: AdditionalInfo? = nil) {
         self.weight = weight
         self.unit = unit
@@ -89,11 +106,23 @@ public struct WeightMeasurement {
 
 
 extension WeightMeasurement {
+    /// The weight value in kg or pounds.
+    ///
+    /// Derrives the weight value as a `Double` considering the devices resolution as defiend by the
+    /// ``WeightScaleFeature`` characteristic.
+    /// - Parameter resolution: The resolution of the ``weight`` property.
+    /// - Returns: The double value of the weight in kg or pounds.
     public func weight(of resolution: WeightScaleFeature.WeightResolution) -> Double {
         Double(weight) * resolution.magnitude(in: unit)
     }
 
 
+    /// The height value in meter or inches.
+    ///
+    /// Derrives the height value as a `Double` consdering the devices resolution as defined by the
+    /// ``WeightScaleFeature`` characteristic.
+    /// - Parameter resolution: The resolution of the ``AdditionalInfo-swift.struct/height`` property.
+    /// - Returns: The double value of the height in meters or inches.
     public func height(of resolution: WeightScaleFeature.HeightResolution) -> Double? {
         (additionalInfo?.height)
             .map(Double.init)

--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -16,23 +16,23 @@ import NIOCore
 /// Refer to GATT Specification Supplement, 3.253 Weight Scale Feature.
 public struct WeightScaleFeature: OptionSet {
     /// Weight resolutions for a weight measurement.
-    public struct WeightResolution: RawRepresentable { // TODO: case naming?
+    public struct WeightResolution: RawRepresentable {
         /// Unspecified resolution, falling back to the default.
         public static let unspecified = WeightResolution(forceRawValue: 0)
         /// Resolution of 0.5 kg or 1 lb.
-        public static let gradeOne = WeightResolution(forceRawValue: 1)
+        public static let resolution500g = WeightResolution(forceRawValue: 1)
         /// Resolution 0.2 kg or 0.5 lb.
-        public static let gradeTwo = WeightResolution(forceRawValue: 2)
+        public static let resolution200g = WeightResolution(forceRawValue: 2)
         /// Resolution 0.1 kg or 0.2 lb.
-        public static let gradeThree = WeightResolution(forceRawValue: 3)
+        public static let resolution100g = WeightResolution(forceRawValue: 3)
         /// Resolution 0.05 kg or 0.1 lb.
-        public static let gradeFour = WeightResolution(forceRawValue: 4)
+        public static let resolution50g = WeightResolution(forceRawValue: 4)
         /// Resolution 0.02 kg or 0.05 lb.
-        public static let gradeFive = WeightResolution(forceRawValue: 5)
+        public static let resolution20g = WeightResolution(forceRawValue: 5)
         /// Resolution 0.01 kg or 0.02 lb.
-        public static let gradeSix = WeightResolution(forceRawValue: 6)
+        public static let resolution10g = WeightResolution(forceRawValue: 6)
         /// Resolution 0.005 kg or 0.01 lb.
-        public static let gradeSeven = WeightResolution(forceRawValue: 7)
+        public static let resolution5g = WeightResolution(forceRawValue: 7)
 
         public let rawValue: UInt8
 
@@ -49,51 +49,51 @@ public struct WeightScaleFeature: OptionSet {
         }
 
 
-        func magnitude(in unit: WeightMeasurement.Unit) -> Double {
+        func magnitude(in unit: WeightMeasurement.Unit) -> Double { // swiftlint:disable:this cyclomatic_complexity function_body_length
             switch self {
-            case .gradeOne:
+            case .resolution500g:
                 switch unit {
                 case .si:
                     0.5
                 case .imperial:
                     1
                 }
-            case .gradeTwo:
+            case .resolution200g:
                 switch unit {
                 case .si:
                     0.2
                 case .imperial:
                     0.5
                 }
-            case .gradeThree:
+            case .resolution100g:
                 switch unit {
                 case .si:
                     0.1
                 case .imperial:
                     0.2
                 }
-            case .gradeFour:
+            case .resolution50g:
                 switch unit {
                 case .si:
                     0.05
                 case .imperial:
                     0.1
                 }
-            case .gradeFive:
+            case .resolution20g:
                 switch unit {
                 case .si:
                     0.02
                 case .imperial:
                     0.05
                 }
-            case .gradeSix:
+            case .resolution10g:
                 switch unit {
                 case .si:
                     0.01
                 case .imperial:
                     0.02
                 }
-            case .unspecified, .gradeSeven:
+            case .unspecified, .resolution5g:
                 switch unit {
                 case .si:
                     0.005
@@ -116,11 +116,11 @@ public struct WeightScaleFeature: OptionSet {
         /// Unspecified resolution, falling back to the default.
         public static let unspecified = HeightResolution(forceRawValue: 0)
         /// Resolution of 0.01 meter or 1 inch.
-        public static let gradeOne = HeightResolution(forceRawValue: 1)
+        public static let resolution10mm = HeightResolution(forceRawValue: 1)
         /// Resolution of 0.005 meter or 0.5 inch.
-        public static let gradeTwo = HeightResolution(forceRawValue: 2)
+        public static let resolution5mm = HeightResolution(forceRawValue: 2)
         /// Resolution of 0.001 meter or 0.1 inch.
-        public static let gradeThree = HeightResolution(forceRawValue: 3)
+        public static let resolution1mm = HeightResolution(forceRawValue: 3)
 
         public let rawValue: UInt8
 
@@ -136,23 +136,23 @@ public struct WeightScaleFeature: OptionSet {
             self.rawValue = rawValue
         }
 
-        func magnitude(in unit: WeightMeasurement.Unit) -> Double {
+        func magnitude(in unit: WeightMeasurement.Unit) -> Double { // swiftlint:disable:this cyclomatic_complexity
             switch self {
-            case .gradeOne:
+            case .resolution10mm:
                 switch unit {
                 case .si:
                     0.01
                 case .imperial:
                     1
                 }
-            case .gradeTwo:
+            case .resolution5mm:
                 switch unit {
                 case .si:
                     0.005
                 case .imperial:
                     0.5
                 }
-            case .unspecified, .gradeThree:
+            case .unspecified, .resolution1mm:
                 switch unit {
                 case .si:
                     0.001
@@ -170,12 +170,11 @@ public struct WeightScaleFeature: OptionSet {
         }
     }
 
-    public let rawValue: UInt32
-
-
     public static let timeStampSupported = WeightScaleFeature(rawValue: 1 << 0)
     public static let multipleUsersSupported = WeightScaleFeature(rawValue: 1 << 1)
     public static let bmiSupported = WeightScaleFeature(rawValue: 1 << 2)
+
+    public let rawValue: UInt32
 
     public var weightResolution: WeightResolution {
         let rawValue = UInt8((rawValue >> 3) & 0b1111)

--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -191,8 +191,14 @@ public struct WeightScaleFeature: OptionSet {
         self.rawValue = rawValue
     }
 
-    public init(weightResolution: WeightResolution, heightResolution: HeightResolution) {
-        self.rawValue = (UInt32(weightResolution.rawValue) << 3) & (UInt32(heightResolution.rawValue) << 7)
+    /// Create new weight scale features.
+    /// - Parameters:
+    ///   - weightResolution: The resolution for weight values for a ``WeightMeasurement``.
+    ///   - heightResolution: The resolution for height values for a ``WeightMeasurement``.
+    ///   - options: Additional flags and options of ``WeightScaleFeature`` (e.g., BMI support or multi user support).
+    public init(weightResolution: WeightResolution, heightResolution: HeightResolution, options: WeightScaleFeature...) {
+        let rawValue = (UInt32(weightResolution.rawValue) << 3) & (UInt32(heightResolution.rawValue) << 7)
+        self = WeightScaleFeature(rawValue: rawValue).union(WeightScaleFeature(options))
     }
 }
 

--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -1,0 +1,221 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// Features of a weight scale.
+///
+/// Refer to GATT Specification Supplement, 3.253 Weight Scale Feature.
+public struct WeightScaleFeature: OptionSet {
+    /// Weight resolutions for a weight measurement.
+    public struct WeightResolution: RawRepresentable { // TODO: case naming?
+        /// Unspecified resolution, falling back to the default.
+        public static let unspecified = WeightResolution(forceRawValue: 0)
+        /// Resolution of 0.5 kg or 1 lb.
+        public static let gradeOne = WeightResolution(forceRawValue: 1)
+        /// Resolution 0.2 kg or 0.5 lb.
+        public static let gradeTwo = WeightResolution(forceRawValue: 2)
+        /// Resolution 0.1 kg or 0.2 lb.
+        public static let gradeThree = WeightResolution(forceRawValue: 3)
+        /// Resolution 0.05 kg or 0.1 lb.
+        public static let gradeFour = WeightResolution(forceRawValue: 4)
+        /// Resolution 0.02 kg or 0.05 lb.
+        public static let gradeFive = WeightResolution(forceRawValue: 5)
+        /// Resolution 0.01 kg or 0.02 lb.
+        public static let gradeSix = WeightResolution(forceRawValue: 6)
+        /// Resolution 0.005 kg or 0.01 lb.
+        public static let gradeSeven = WeightResolution(forceRawValue: 7)
+
+        public let rawValue: UInt8
+
+        public init?(rawValue: UInt8) {
+            guard rawValue <= 0b1111 else {
+                return nil
+            }
+            self.rawValue = rawValue
+        }
+
+        private init(forceRawValue rawValue: UInt8) {
+            precondition(rawValue <= 0b1111, "Value out of range: \(rawValue)")
+            self.rawValue = rawValue
+        }
+
+
+        func magnitude(in unit: WeightMeasurement.Unit) -> Double {
+            switch self {
+            case .gradeOne:
+                switch unit {
+                case .si:
+                    0.5
+                case .imperial:
+                    1
+                }
+            case .gradeTwo:
+                switch unit {
+                case .si:
+                    0.2
+                case .imperial:
+                    0.5
+                }
+            case .gradeThree:
+                switch unit {
+                case .si:
+                    0.1
+                case .imperial:
+                    0.2
+                }
+            case .gradeFour:
+                switch unit {
+                case .si:
+                    0.05
+                case .imperial:
+                    0.1
+                }
+            case .gradeFive:
+                switch unit {
+                case .si:
+                    0.02
+                case .imperial:
+                    0.05
+                }
+            case .gradeSix:
+                switch unit {
+                case .si:
+                    0.01
+                case .imperial:
+                    0.02
+                }
+            case .unspecified, .gradeSeven:
+                switch unit {
+                case .si:
+                    0.005
+                case .imperial:
+                    0.01
+                }
+            default:
+                switch unit {
+                case .si:
+                    0.005
+                case .imperial:
+                    0.01
+                }
+            }
+        }
+    }
+
+
+    public struct HeightResolution: RawRepresentable {
+        /// Unspecified resolution, falling back to the default.
+        public static let unspecified = HeightResolution(forceRawValue: 0)
+        /// Resolution of 0.01 meter or 1 inch.
+        public static let gradeOne = HeightResolution(forceRawValue: 1)
+        /// Resolution of 0.005 meter or 0.5 inch.
+        public static let gradeTwo = HeightResolution(forceRawValue: 2)
+        /// Resolution of 0.001 meter or 0.1 inch.
+        public static let gradeThree = HeightResolution(forceRawValue: 3)
+
+        public let rawValue: UInt8
+
+        public init?(rawValue: UInt8) {
+            guard rawValue <= 0b111 else {
+                return nil
+            }
+            self.rawValue = rawValue
+        }
+
+        private init(forceRawValue rawValue: UInt8) {
+            precondition(rawValue <= 0b111, "Value out of range: \(rawValue)")
+            self.rawValue = rawValue
+        }
+
+        func magnitude(in unit: WeightMeasurement.Unit) -> Double {
+            switch self {
+            case .gradeOne:
+                switch unit {
+                case .si:
+                    0.01
+                case .imperial:
+                    1
+                }
+            case .gradeTwo:
+                switch unit {
+                case .si:
+                    0.005
+                case .imperial:
+                    0.5
+                }
+            case .unspecified, .gradeThree:
+                switch unit {
+                case .si:
+                    0.001
+                case .imperial:
+                    0.1
+                }
+            default:
+                switch unit {
+                case .si:
+                    0.001
+                case .imperial:
+                    0.01
+                }
+            }
+        }
+    }
+
+    public let rawValue: UInt32
+
+
+    public static let timeStampSupported = WeightScaleFeature(rawValue: 1 << 0)
+    public static let multipleUsersSupported = WeightScaleFeature(rawValue: 1 << 1)
+    public static let bmiSupported = WeightScaleFeature(rawValue: 1 << 2)
+
+    public var weightResolution: WeightResolution {
+        let rawValue = UInt8((rawValue >> 3) & 0b1111)
+        return WeightResolution(rawValue: rawValue) ?? .unspecified
+    }
+
+    public var heightResolution: HeightResolution {
+        let rawValue = UInt8((rawValue >> 7) & 0b111)
+        return HeightResolution(rawValue: rawValue) ?? .unspecified
+    }
+
+
+    public init(rawValue: UInt32) {
+        self.rawValue = rawValue
+    }
+
+    public init(weightResolution: WeightResolution, heightResolution: HeightResolution) {
+        self.rawValue = (UInt32(weightResolution.rawValue) << 3) & (UInt32(heightResolution.rawValue) << 7)
+    }
+}
+
+
+extension WeightScaleFeature.WeightResolution: Hashable, Sendable {}
+
+
+extension WeightScaleFeature.HeightResolution: Hashable, Sendable {}
+
+
+extension WeightScaleFeature: Hashable, Sendable {}
+
+
+extension WeightScaleFeature: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Services/BatteryService.swift
+++ b/Sources/BluetoothServices/Services/BatteryService.swift
@@ -1,0 +1,31 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import class CoreBluetooth.CBUUID
+import SpeziBluetooth
+
+
+/// Bluetooth Battery Service.
+///
+/// This class partially implements the Bluetooth [Battery Service 1.1](https://www.bluetooth.com/specifications/specs/battery-service).
+/// - Note: The current implementation only implements mandatory characteristics.
+public final class BatteryService: BluetoothService, @unchecked Sendable {
+    public static let id = CBUUID(string: "180F")
+
+
+    /// Battery Level in percent.
+    ///
+    /// Battery Level in percent (range 0 to 100).
+    /// 100 represetns fully charged, 0 represents fully discharged.
+    /// All other values are reserved.
+    @Characteristic(id: "2A19", notify: true)
+    public var batteryLevel: UInt8?
+
+
+    public init() {}
+}

--- a/Sources/BluetoothServices/Services/BloodPressureService.swift
+++ b/Sources/BluetoothServices/Services/BloodPressureService.swift
@@ -1,0 +1,40 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import class CoreBluetooth.CBUUID
+import SpeziBluetooth
+
+
+/// Bluetooth Blood Pressure Service implementation.
+///
+/// This class partially implements the Bluetooth [Blood Pressure Service 1.1](https://www.bluetooth.com/specifications/specs/blood-pressure-service-1-1-1).
+/// - Note: The Enhance Blood Pressure Service is currently not supported.
+public final class BloodPressureService: BluetoothService, @unchecked Sendable {
+    public static let id = CBUUID(string: "1810")
+
+    /// Receive blood pressure measurements
+    ///
+    /// - Note: This characteristic is required and indicate-only.
+    @Characteristic(id: "2A35", notify: true)
+    public var bloodPressureMeasurement: BloodPressureMeasurement?
+
+    /// Describe supported features of the blood pressure cuff.
+    ///
+    /// - Note: This characteristic is required and read-only (optionally supports indicate).
+    @Characteristic(id: "2A49", notify: true)
+    public var features: BloodPressureFeature?
+
+    /// Receive intermdaite cuff pressure.
+    ///
+    /// - Note: This characteristic is optional and notify-only.
+    @Characteristic(id: "2A36", notify: true)
+    public var intermediateCuffPressure: IntermediateCuffPressure?
+
+
+    public init() {}
+}

--- a/Sources/BluetoothServices/Services/DeviceInformationService.swift
+++ b/Sources/BluetoothServices/Services/DeviceInformationService.swift
@@ -60,38 +60,4 @@ public final class DeviceInformationService: BluetoothService, @unchecked Sendab
 
 
     public init() {}
-
-
-    /// Queries all present device information.
-    public func retrieveDeviceInformation() async throws {
-        if $manufacturerName.isPresent {
-            try await self.$manufacturerName.read()
-        }
-        if $modelNumber.isPresent {
-            try await self.$modelNumber.read()
-        }
-        if $serialNumber.isPresent {
-            try await self.$serialNumber.read()
-        }
-
-        if $hardwareRevision.isPresent {
-            try await self.$hardwareRevision.read()
-        }
-        if $firmwareRevision.isPresent {
-            try await self.$firmwareRevision.read()
-        }
-        if $softwareRevision.isPresent {
-            try await self.$softwareRevision.read()
-        }
-
-        if $systemID.isPresent {
-            try await self.$systemID.read()
-        }
-        if $regulatoryCertificationDataList.isPresent {
-            try await self.$regulatoryCertificationDataList.read()
-        }
-        if $pnpID.isPresent {
-            try await self.$pnpID.read()
-        }
-    }
 }

--- a/Sources/BluetoothServices/Services/HealthThermometerService.swift
+++ b/Sources/BluetoothServices/Services/HealthThermometerService.swift
@@ -18,7 +18,7 @@ public final class HealthThermometerService: BluetoothService, @unchecked Sendab
 
     /// Receive temperature measurements.
     ///
-    /// - Note: This is characteristic required and indicate-only.
+    /// - Note: This characteristic is required and indicate-only.
     @Characteristic(id: "2A1C", notify: true)
     public var temperatureMeasurement: TemperatureMeasurement?
     /// The body location of the temperature measurement.
@@ -26,19 +26,19 @@ public final class HealthThermometerService: BluetoothService, @unchecked Sendab
     /// Either use this static property or dynamically set it within ``TemperatureMeasurement/temperatureType``.
     /// Don't use both. Either of one is required.
     ///
-    /// - Note: This is characteristic optional and read-only.
+    /// - Note: This characteristic is optional and read-only.
     @Characteristic(id: "2A1D")
     public var temperatureType: TemperatureType?
     /// Receive intermediate temperature values to a device for display purposes while a measurement is in progress.
     ///
-    /// - Note: This is characteristic optional and notify-only.
+    /// - Note: This characteristic is optional and notify-only.
     @Characteristic(id: "2A1E", notify: true)
     public var intermediateTemperature: TemperatureMeasurement?
     /// The measurement interval between two measurements.
     ///
     /// Describes the measurements of ``temperatureMeasurement``.
     ///
-    /// - Note: This is characteristic optional and read-only.
+    /// - Note: This characteristic is optional and read-only.
     ///     Optionally it might indicate and writeable.
     @Characteristic(id: "2A21")
     public var measurementInterval: MeasurementInterval?

--- a/Sources/BluetoothServices/Services/WeightScaleService.swift
+++ b/Sources/BluetoothServices/Services/WeightScaleService.swift
@@ -14,7 +14,7 @@ import SpeziBluetooth
 ///
 /// This class implements the Bluetooth [Weight Scale Service 1.0](https://www.bluetooth.com/specifications/specs/weight-scale-service-1-0).
 public final class WeightScaleService: BluetoothService, @unchecked Sendable {
-    public static let id = CBUUId(string: "181D")
+    public static let id = CBUUID(string: "181D")
 
     /// Receive weight measurements.
     ///

--- a/Sources/BluetoothServices/Services/WeightScaleService.swift
+++ b/Sources/BluetoothServices/Services/WeightScaleService.swift
@@ -1,0 +1,33 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import class CoreBluetooth.CBUUID
+import SpeziBluetooth
+
+
+/// Bluetooth Weight Scale Service implementation.
+///
+/// This class implements the Bluetooth [Weight Scale Service 1.0](https://www.bluetooth.com/specifications/specs/weight-scale-service-1-0).
+public final class WeightScaleService: BluetoothService, @unchecked Sendable {
+    public static let id = CBUUId(string: "181D")
+
+    /// Receive weight measurements.
+    ///
+    /// - Note: This characteristic is required and indicate-only.
+    @Characteristic(id: "2A9D", notify: true)
+    public var weightMeasurement: WeightMeasurement?
+
+    /// Describe supported features and value resolutions of the weight scale.
+    ///
+    /// - Note: This characteristic is required and read-only.
+    @Characteristic(id: "2A9E")
+    public var features: WeightScaleFeature?
+
+
+    public init() {}
+}

--- a/Sources/SpeziBluetooth/Bluetooth.swift
+++ b/Sources/SpeziBluetooth/Bluetooth.swift
@@ -62,7 +62,7 @@ import Spezi
 ///     @DeviceAction(\.disconnect)
 ///     var disconnect
 ///
-///     init() {} // required initializer
+///     required init() {}
 /// }
 /// ```
 ///

--- a/Sources/SpeziBluetooth/SpeziBluetooth.docc/SpeziBluetooth.md
+++ b/Sources/SpeziBluetooth/SpeziBluetooth.docc/SpeziBluetooth.md
@@ -106,7 +106,7 @@ class MyDevice: BluetoothDevice {
     @DeviceAction(\.disconnect)
     var disconnect
 
-    init() {} // required initializer
+    required init() {}
 }
 ```
 

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -199,8 +199,10 @@ final class BluetoothServicesTests: XCTestCase {
     func testCharacteristics() async throws {
         _ = TestService()
         _ = HealthThermometerService()
-        let info = DeviceInformationService()
-        try await info.retrieveDeviceInformation()
+        _ = DeviceInformationService()
+        _ = WeightScaleService()
+        _ = BloodPressureService()
+        _ = BatteryService()
     }
 
     func testUUID() {

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -104,6 +104,34 @@ final class BluetoothServicesTests: XCTestCase {
         try testIdentity(from: features3)
     }
 
+    func testWeightMeasurement() throws {
+        let time = DateTime(hours: 13, minutes: 12, seconds: 12)
+
+        try testIdentity(from: WeightMeasurement(weight: 123, unit: .si))
+        try testIdentity(from: WeightMeasurement(weight: 123, unit: .si, timeStamp: time))
+        try testIdentity(from: WeightMeasurement(weight: 123, unit: .si, timeStamp: time, userId: 23))
+        try testIdentity(from: WeightMeasurement(weight: 123, unit: .si, additionalInfo: .init(bmi: 230, height: 1760)))
+    }
+
+    func testWeightScaleFeature() throws {
+        let features: WeightScaleFeature = [
+            .bmiSupported,
+            .multipleUsersSupported,
+            .timeStampSupported
+        ]
+
+        XCTAssertTrue(features.contains(.bmiSupported))
+        XCTAssertTrue(features.contains(.multipleUsersSupported))
+        XCTAssertTrue(features.contains(.timeStampSupported))
+
+        let features2: WeightScaleFeature = [.bmiSupported]
+        let features3: WeightScaleFeature = [.timeStampSupported]
+
+        try testIdentity(from: features)
+        try testIdentity(from: features2)
+        try testIdentity(from: features3)
+    }
+
     func testTemperatureType() throws {
         for type in TemperatureType.allCases {
             try testIdentity(from: type)

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -114,12 +114,12 @@ final class BluetoothServicesTests: XCTestCase {
     }
 
     func testWeightMeasurementResolutions() throws {
-        func weightOf(_ weight: UInt16, unit: WeightMeasurement.Unit = .si, resolution: WeightScaleFeature.WeightResolution) -> Double {
+        func weightOf(_ weight: UInt16, resolution: WeightScaleFeature.WeightResolution, unit: WeightMeasurement.Unit = .si) -> Double {
             WeightMeasurement(weight: weight, unit: unit)
                 .weight(of: resolution)
         }
 
-        func heightOf(_ height: UInt16, unit: WeightMeasurement.Unit = .si, resolution: WeightScaleFeature.HeightResolution) -> Double? {
+        func heightOf(_ height: UInt16, resolution: WeightScaleFeature.HeightResolution, unit: WeightMeasurement.Unit = .si) -> Double? {
             WeightMeasurement(weight: 120, unit: unit, additionalInfo: .init(bmi: 230, height: height))
                 .height(of: resolution)
         }
@@ -133,24 +133,24 @@ final class BluetoothServicesTests: XCTestCase {
         XCTAssertEqual(weightOf(120, resolution: .resolution200g), 24)
         XCTAssertEqual(weightOf(120, resolution: .resolution500g), 60)
 
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .unspecified), 1.2)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution5g), 1.2)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution10g), 2.4)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution20g), 6)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution50g), 12)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution100g), 24)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution200g), 60)
-        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution500g), 120)
+        XCTAssertEqual(weightOf(120, resolution: .unspecified, unit: .imperial), 1.2)
+        XCTAssertEqual(weightOf(120, resolution: .resolution5g, unit: .imperial), 1.2)
+        XCTAssertEqual(weightOf(120, resolution: .resolution10g, unit: .imperial), 2.4)
+        XCTAssertEqual(weightOf(120, resolution: .resolution20g, unit: .imperial), 6)
+        XCTAssertEqual(weightOf(120, resolution: .resolution50g, unit: .imperial), 12)
+        XCTAssertEqual(weightOf(120, resolution: .resolution100g, unit: .imperial), 24)
+        XCTAssertEqual(weightOf(120, resolution: .resolution200g, unit: .imperial), 60)
+        XCTAssertEqual(weightOf(120, resolution: .resolution500g, unit: .imperial), 120)
 
         XCTAssertEqual(heightOf(1700, resolution: .unspecified), 1.7)
         XCTAssertEqual(heightOf(1700, resolution: .resolution1mm), 1.7)
         XCTAssertEqual(heightOf(1700, resolution: .resolution5mm), 8.5)
         XCTAssertEqual(heightOf(1700, resolution: .resolution10mm), 17)
 
-        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .unspecified), 6)
-        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution1mm), 6)
-        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution5mm), 30)
-        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution10mm), 60)
+        XCTAssertEqual(heightOf(60, resolution: .unspecified, unit: .imperial), 6)
+        XCTAssertEqual(heightOf(60, resolution: .resolution1mm, unit: .imperial), 6)
+        XCTAssertEqual(heightOf(60, resolution: .resolution5mm, unit: .imperial), 30)
+        XCTAssertEqual(heightOf(60, resolution: .resolution10mm, unit: .imperial), 60)
     }
 
     func testWeightScaleFeature() throws {
@@ -166,7 +166,12 @@ final class BluetoothServicesTests: XCTestCase {
 
         try testIdentity(from: features)
         try testIdentity(from: WeightScaleFeature(weightResolution: .resolution20g, heightResolution: .resolution10mm))
-        try testIdentity(from: WeightScaleFeature(weightResolution: .resolution20g, heightResolution: .resolution10mm, options: .bmiSupported, .multipleUsersSupported))
+        try testIdentity(from: WeightScaleFeature(
+            weightResolution: .resolution20g,
+            heightResolution: .resolution10mm,
+            options: .bmiSupported,
+            .multipleUsersSupported
+        ))
     }
 
     func testTemperatureType() throws {

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -113,6 +113,46 @@ final class BluetoothServicesTests: XCTestCase {
         try testIdentity(from: WeightMeasurement(weight: 123, unit: .si, additionalInfo: .init(bmi: 230, height: 1760)))
     }
 
+    func testWeightMeasurementResolutions() throws {
+        func weightOf(_ weight: UInt16, unit: WeightMeasurement.Unit = .si, resolution: WeightScaleFeature.WeightResolution) -> Double {
+            WeightMeasurement(weight: weight, unit: unit)
+                .weight(of: resolution)
+        }
+
+        func heightOf(_ height: UInt16, unit: WeightMeasurement.Unit = .si, resolution: WeightScaleFeature.HeightResolution) -> Double? {
+            WeightMeasurement(weight: 120, unit: unit, additionalInfo: .init(bmi: 230, height: height))
+                .height(of: resolution)
+        }
+
+        XCTAssertEqual(weightOf(120, resolution: .unspecified), 0.6)
+        XCTAssertEqual(weightOf(120, resolution: .resolution5g), 0.6)
+        XCTAssertEqual(weightOf(120, resolution: .resolution10g), 1.2)
+        XCTAssertEqual(weightOf(120, resolution: .resolution20g), 2.4)
+        XCTAssertEqual(weightOf(120, resolution: .resolution50g), 6)
+        XCTAssertEqual(weightOf(120, resolution: .resolution100g), 12)
+        XCTAssertEqual(weightOf(120, resolution: .resolution200g), 24)
+        XCTAssertEqual(weightOf(120, resolution: .resolution500g), 60)
+
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .unspecified), 1.2)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution5g), 1.2)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution10g), 2.4)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution20g), 6)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution50g), 12)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution100g), 24)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution200g), 60)
+        XCTAssertEqual(weightOf(120, unit: .imperial, resolution: .resolution500g), 120)
+
+        XCTAssertEqual(heightOf(1700, resolution: .unspecified), 1.7)
+        XCTAssertEqual(heightOf(1700, resolution: .resolution1mm), 1.7)
+        XCTAssertEqual(heightOf(1700, resolution: .resolution5mm), 8.5)
+        XCTAssertEqual(heightOf(1700, resolution: .resolution10mm), 17)
+
+        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .unspecified), 6)
+        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution1mm), 6)
+        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution5mm), 30)
+        XCTAssertEqual(heightOf(60, unit: .imperial, resolution: .resolution10mm), 60)
+    }
+
     func testWeightScaleFeature() throws {
         let features: WeightScaleFeature = [
             .bmiSupported,
@@ -124,12 +164,9 @@ final class BluetoothServicesTests: XCTestCase {
         XCTAssertTrue(features.contains(.multipleUsersSupported))
         XCTAssertTrue(features.contains(.timeStampSupported))
 
-        let features2: WeightScaleFeature = [.bmiSupported]
-        let features3: WeightScaleFeature = [.timeStampSupported]
-
         try testIdentity(from: features)
-        try testIdentity(from: features2)
-        try testIdentity(from: features3)
+        try testIdentity(from: WeightScaleFeature(weightResolution: .resolution20g, heightResolution: .resolution10mm))
+        try testIdentity(from: WeightScaleFeature(weightResolution: .resolution20g, heightResolution: .resolution10mm, options: .bmiSupported, .multipleUsersSupported))
     }
 
     func testTemperatureType() throws {


### PR DESCRIPTION
# Adding support for for weight scale service

## :recycle: Current situation & Problem
This PR adds support for encoding and decoding the characteristics of a Weight Scale Service. Particularly, we added methods to convert weight measurements to their respective double representation.
Additionally, we add pre-implemented, reusable service implementations for the Blood Pressure Service and the Weight Scale Service. Lastly we add a minimal Battery Service implementation.


## :gear: Release Notes 
* Add `WeightMeasurement` characteristic.
* Add `WeightScaleFeature` characteristic.
* Add `BloodPressureService`.
* Add `WeightScaleService`.
* Add basic `BatteryService`.


## :books: Documentation
New types have been documented.


## :white_check_mark: Testing
Encoding and decoding of new characteristics were unit tested.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
