### PR TITLE
Add support for the Current Time Service

### DIFF
--- a/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Characteristics.md
@@ -24,14 +24,18 @@ which natively integrates with SpeziBluetooth-defined services.
 
 ## Topics
 
-### Generic
-
-- ``DateTime``
-
 ### Device Information
 
 - ``PnPID``
 - ``VendorIDSource``
+
+### Time
+
+- ``DateTime``
+- ``DayOfWeek``
+- ``DayDateTime``
+- ``ExactTime256``
+- ``CurrentTime``
 
 ### Blood Pressure
 

--- a/Sources/BluetoothServices/BluetoothServices.docc/Services.md
+++ b/Sources/BluetoothServices/BluetoothServices.docc/Services.md
@@ -20,8 +20,9 @@ Below is a list of reusable Bluetooth service implementations of standardized Bl
 
 ### Core Services
 
-- ``DeviceInformationService``
 - ``BatteryService``
+- ``CurrentTimeService``
+- ``DeviceInformationService``
 
 ### Health Domain
 

--- a/Sources/BluetoothServices/Characteristics/Time/CurrentTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/CurrentTime.swift
@@ -1,0 +1,89 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// The current time and a reason for adjustment.
+///
+/// Refer to GATT Specification Supplement, 3.62 Current Time.
+public struct CurrentTime {
+    /// The reason why a peripheral adjusted its current time.
+    public struct AdjustReason: OptionSet {
+        public let rawValue: UInt8
+
+        /// The time information on the device was manually set or changed.
+        ///
+        /// - Note: Also set this flag if the time zone or DST offset were changed manually.
+        public static let manualTimeUpdate = AdjustReason(rawValue: 1 << 0)
+        /// Received time information from an external time reference source.
+        public static let externalReferenceTimeUpdate = AdjustReason(rawValue: 1 << 1)
+        /// The time information was changed due to a change of time zone.
+        public static let changeOfTimeZone = AdjustReason(rawValue: 1 << 2)
+        /// The time information was changed due to a change of Daylight Savings Time (DST).
+        public static let changeOfDST = AdjustReason(rawValue: 1 << 3)
+
+        public init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
+    }
+
+    /// The current time.
+    public let time: ExactTime256
+    /// The reason for adjusting time.
+    public let adjustReason: AdjustReason
+
+
+    /// Initialize a new current time.
+    /// - Parameters:
+    ///   - time: The current, exact time.
+    ///   - adjustReason: The peripheral reported reason for adjusting time.
+    public init(time: ExactTime256, adjustReason: AdjustReason = []) {
+        self.time = time
+        self.adjustReason = adjustReason
+    }
+}
+
+
+extension CurrentTime.AdjustReason: Hashable, Sendable {}
+
+
+extension CurrentTime: Hashable, Sendable {}
+
+
+extension CurrentTime.AdjustReason: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}
+
+
+extension CurrentTime: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let time = ExactTime256(from: &byteBuffer, preferredEndianness: endianness),
+              let adjustReason = AdjustReason(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.init(time: time, adjustReason: adjustReason)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        time.encode(to: &byteBuffer, preferredEndianness: endianness)
+        adjustReason.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/Time/DateTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DateTime.swift
@@ -7,40 +7,49 @@
 //
 
 import ByteCoding
+import Foundation
 import NIO
 
 
-/// Date Time characteristic to represent date and time.
+/// Date and time information.
 ///
 /// Refer to GATT Specification Supplement, 3.70 Date Time.
 public struct DateTime {
-    public enum Month: UInt8 {
+    /// The month.
+    public struct Month: RawRepresentable {
         /// Unknown month.
-        case unknown
+        public static let unknown = Month(rawValue: 0)
         /// The month January.
-        case january
+        public static let january = Month(rawValue: 1)
         /// The month February.
-        case february
+        public static let february = Month(rawValue: 2)
         /// The month March.
-        case march
+        public static let march = Month(rawValue: 3)
         /// The month April.
-        case april
+        public static let april = Month(rawValue: 4)
         /// The month Mai.
-        case mai
+        public static let mai = Month(rawValue: 5)
         /// The month June.
-        case june
+        public static let june = Month(rawValue: 6)
         /// The month July.
-        case july
+        public static let july = Month(rawValue: 7)
         /// The month August.
-        case august
+        public static let august = Month(rawValue: 8)
         /// The month September.
-        case september
+        public static let september = Month(rawValue: 9)
         /// The month October.
-        case october
+        public static let october = Month(rawValue: 10)
         /// The month November.
-        case november
+        public static let november = Month(rawValue: 11)
         /// The month December.
-        case december
+        public static let december = Month(rawValue: 12)
+
+        public let rawValue: UInt8
+
+
+        public init(rawValue: UInt8) {
+            self.rawValue = rawValue
+        }
     }
 
     /// Year as defined by the Gregorian calendar.
@@ -88,6 +97,69 @@ public struct DateTime {
         self.hours = hours
         self.minutes = minutes
         self.seconds = seconds
+    }
+}
+
+
+extension DateTime {
+    /// The date components representation for the date and time.
+    public var dateComponents: DateComponents {
+        var components = DateComponents()
+
+        // value of zero signals unknown
+        if year > 0 {
+            components.year = Int(year)
+        }
+        if month.rawValue > 0 {
+            components.month = Int(month.rawValue)
+        }
+        if day > 0 {
+            components.day = Int(day)
+        }
+
+        components.hour = Int(hours)
+        components.minute = Int(minutes)
+        components.second = Int(seconds)
+
+        return components
+    }
+
+
+    /// Convert to Swift Date representation.
+    ///
+    /// Uses the current `Calendar`.
+    /// Returns `nil` if a date with matching components couldn't be found.
+    public var date: Date? {
+        Calendar.current.date(from: dateComponents)
+    }
+
+
+    /// Initialize date time from date components.
+    ///
+    /// - Note: Returns `nil` if not all required date components (`hour`, `minute`, `second`) are
+    ///     present. Date components `year`, `month` and `day` are optional but required to encode a date information.
+    /// - Parameter components: The Swift Date Components.
+    public init?(from components: DateComponents) {
+        guard let hours = components.hour,
+              let minutes = components.minute,
+              let seconds = components.second else {
+            return nil
+        }
+
+        let year = components.year.map(UInt16.init) ?? 0
+        let month = components.month.map(UInt8.init) ?? 0
+        let day = components.day.map(UInt8.init) ?? 0
+
+        self.init(year: year, month: Month(rawValue: month), day: day, hours: UInt8(hours), minutes: UInt8(minutes), seconds: UInt8(seconds))
+    }
+
+    /// Initialize date time from a date and current `Calendar`.
+    /// - Parameter date: The date to initialize from.
+    public init(from date: Date) {
+        let components = Calendar.current.dateComponents([.hour, .minute, .second, .year, .month, .day], from: date)
+
+        // we know that date components are present, so force-unwrapping is fine
+        self.init(from: components)! // swiftlint:disable:this force_unwrapping
     }
 }
 

--- a/Sources/BluetoothServices/Characteristics/Time/DayDateTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DayDateTime.swift
@@ -1,0 +1,114 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// Represent weekday, date and time.
+///
+/// Refer to GATT Specification Supplement, 3.72 Day Date Time.
+@dynamicMemberLookup
+public struct DayDateTime {
+    /// The date and time.
+    public let dateTime: DateTime
+    /// The weekday.
+    public let dayOfWeek: DayOfWeek
+
+
+    /// Initialize a new weekday, date and time.
+    /// - Parameters:
+    ///   - dateTime: The ``DateTime`` information.
+    ///   - dayOfWeek: The day of week if available.
+    public init(dateTime: DateTime, dayOfWeek: DayOfWeek) {
+        self.dateTime = dateTime
+        self.dayOfWeek = dayOfWeek
+    }
+
+
+    /// Dynamic access for date and time.
+    /// - Parameter keyPath: KeyPath to the underlying ``DateTime`` information.
+    /// - Returns: Returns the time value.
+    public subscript<Value>(dynamicMember keyPath: KeyPath<DateTime, Value>) -> Value {
+        dateTime[keyPath: keyPath]
+    }
+}
+
+
+extension DayDateTime {
+    /// The date components representation for the date and time.
+    public var dateComponents: DateComponents {
+        var components = dateTime.dateComponents
+
+        if dayOfWeek.rawValue > 0 && dayOfWeek.rawValue <= 7 {
+            var weekday = dayOfWeek.rawValue + 1
+            if weekday > 7 {
+                weekday = 1
+            }
+            components.weekday = Int(weekday)
+        }
+
+        return components
+    }
+
+    /// Initialize weekday, date and time from date components.
+    ///
+    /// - Note: Returns `nil` if not all required date components (`hour`, `minute`, `second`) are
+    ///     present. Date components `year`, `month` and `day` are optional but required to encode a date information.
+    ///     Date component `weekday` is optional but required to encode day of week information.
+    /// - Parameter components: The Swift Date Components.
+    public init?(from components: DateComponents) {
+        guard let dateTime = DateTime(from: components) else {
+            return nil
+        }
+
+        var weekday = components.weekday ?? 0
+
+        // `dayOfWeek` is 1-7 with 1 is Monday, `DateComponents/weekday` is 1-7 with 1 is Sunday.
+        if weekday > 0 && weekday <= 7 {
+            weekday -= 1
+            if weekday == 0 {
+                weekday = 7
+            }
+        }
+
+        self.dateTime = dateTime
+        self.dayOfWeek = DayOfWeek(rawValue: UInt8(weekday))
+    }
+
+    /// Initialize date time from a date and current `Calendar`.
+    /// - Parameter date: The date to initialize from.
+    public init(from date: Date) {
+        let components = Calendar.current.dateComponents([.hour, .minute, .second, .year, .month, .day, .weekday], from: date)
+
+        // we know that date components are present, so force-unwrapping is fine
+        self.init(from: components)! // swiftlint:disable:this force_unwrapping
+    }
+}
+
+
+extension DayDateTime: Hashable, Sendable {}
+
+
+extension DayDateTime: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let dateTime = DateTime(from: &byteBuffer, preferredEndianness: endianness),
+              let dayOfWeek = DayOfWeek(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+
+        self.init(dateTime: dateTime, dayOfWeek: dayOfWeek)
+    }
+
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        dateTime.encode(to: &byteBuffer, preferredEndianness: endianness)
+        dayOfWeek.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/Time/DayOfWeek.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DayOfWeek.swift
@@ -1,0 +1,62 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// The day of week.
+///
+/// Specifies the day within a seven-day week as specified in IOS 8601.
+///
+/// Refer to GATT Specification Supplement, 3.73 Day of Week.
+public struct DayOfWeek: RawRepresentable {
+    /// Unknown day of week.
+    public static let unknown = DayOfWeek(rawValue: 0)
+    /// Monday.
+    public static let monday = DayOfWeek(rawValue: 1)
+    /// Tuesday.
+    public static let tuesday = DayOfWeek(rawValue: 2)
+    /// Wednesday.
+    public static let wednesday = DayOfWeek(rawValue: 3)
+    /// Thursday.
+    public static let thursday = DayOfWeek(rawValue: 4)
+    /// Friday.
+    public static let friday = DayOfWeek(rawValue: 5)
+    /// Saturday.
+    public static let saturday = DayOfWeek(rawValue: 6)
+    /// Sunday.
+    public static let sunday = DayOfWeek(rawValue: 7)
+
+
+    /// The raw value.
+    public let rawValue: UInt8
+
+
+    public init(rawValue: UInt8) {
+        self.rawValue = rawValue
+    }
+}
+
+
+extension DayOfWeek: Hashable, Sendable {}
+
+
+extension DayOfWeek: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(rawValue: rawValue)
+    }
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Characteristics/Time/ExactTime256.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/ExactTime256.swift
@@ -1,0 +1,135 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import ByteCoding
+import Foundation
+import NIOCore
+
+
+/// Exact time representing using weekday, date and time including fractions of seconds.
+///
+/// Refer to GATT Specification Supplement, 3.91 Exact Time 256.
+@dynamicMemberLookup
+public struct ExactTime256 {
+    /// The weekday, date and time.
+    public let dayDateTime: DayDateTime
+    /// Number of 1/256 fractions of a second.
+    ///
+    /// Set to zero if not supported.
+    public let fractions256: UInt8
+
+
+    /// Fractions in second.
+    public var fractions: Double {
+        Double(fractions256) * (1.0 / 256.0)
+    }
+
+
+    /// Initialize a new exact time with 256 bit second fractions.
+    /// - Parameters:
+    ///   - dayDateTime: The weekday, date and time.
+    ///   - fractions256: The number of 1/256 fractions of a second.
+    ///     Set to zero if not supported.
+    public init(dayDateTime: DayDateTime, fractions256: UInt8) {
+        self.dayDateTime = dayDateTime
+        self.fractions256 = fractions256
+    }
+
+
+    /// Dynamic access for weekday, date and time.
+    /// - Parameter keyPath: The KeyPath to a ``DayDateTime`` property.
+    /// - Returns: Returns the time value.
+    public subscript<Value>(dynamicMember keyPath: KeyPath<DayDateTime, Value>) -> Value {
+        dayDateTime[keyPath: keyPath]
+    }
+}
+
+
+extension ExactTime256 {
+    /// The factor to convert the 1/256 seconds fraction to nanoseconds.
+    ///
+    ///         1/256 = 0,00390625 => * 10^9 is 3906250
+    private static let fractionNanosecondFactor = 3906250 // saves us from using doubles :)
+
+    /// The date components representation for the date and time.
+    public var dateComponents: DateComponents {
+        var components = dayDateTime.dateComponents
+
+        components.nanosecond = Int(fractions256) * Self.fractionNanosecondFactor
+
+        return components
+    }
+
+    /// Convert to Swift Date representation.
+    ///
+    /// Uses the current `Calendar`.
+    /// Returns `nil` if a date with matching components couldn't be found.
+    public var date: Date? {
+        Calendar.current.date(from: dateComponents)
+    }
+
+
+    /// Initialize weekday, date and time from date components.
+    ///
+    /// - Note: Returns `nil` if not all required date components (`hour`, `minute`, `second`) are
+    ///     present. Date components `year`, `month` and `day` are optional but required to encode a date information.
+    ///     Date component `weekday` is optional but required to encode day of week information.
+    ///     Date component `nanosecond` is optional but required to encode second fractions.
+    /// - Parameter components: The Swift Date Components.
+    public init?(from components: DateComponents) {
+        var components = components
+
+        let fractions256: UInt8
+        if var nanoseconds = components.nanosecond {
+            if nanoseconds >= 256 * Self.fractionNanosecondFactor { // = 10^9
+                components.second = (components.second ?? 0) + nanoseconds / 1000_000_000
+                nanoseconds %= 1000_000_000
+            }
+
+            // UInt8 conversion is guaranteed to work due to the check above
+            fractions256 = UInt8(nanoseconds / Self.fractionNanosecondFactor)
+        } else {
+            fractions256 = 0
+        }
+
+        guard let dayDateTime = DayDateTime(from: components) else {
+            return nil
+        }
+
+        self.init(dayDateTime: dayDateTime, fractions256: fractions256)
+    }
+
+    /// Initialize date time from a date and current `Calendar`.
+    /// - Parameter date: The date to initialize from.
+    public init(from date: Date) {
+        let components = Calendar.current.dateComponents([.hour, .minute, .second, .year, .month, .day, .weekday, .nanosecond], from: date)
+
+        // we know that date components are present, so force-unwrapping is fine
+        self.init(from: components)! // swiftlint:disable:this force_unwrapping
+    }
+}
+
+
+extension ExactTime256: Hashable, Sendable {}
+
+
+extension ExactTime256: ByteCodable {
+    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        guard let dayDateTime = DayDateTime(from: &byteBuffer, preferredEndianness: endianness),
+              let fractions256 = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            return nil
+        }
+        self.init(dayDateTime: dayDateTime, fractions256: fractions256)
+    }
+
+
+    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+        dayDateTime.encode(to: &byteBuffer, preferredEndianness: endianness)
+        fractions256.encode(to: &byteBuffer, preferredEndianness: endianness)
+    }
+}

--- a/Sources/BluetoothServices/Services/BatteryService.swift
+++ b/Sources/BluetoothServices/Services/BatteryService.swift
@@ -21,7 +21,7 @@ public final class BatteryService: BluetoothService, @unchecked Sendable {
     /// Battery Level in percent.
     ///
     /// Battery Level in percent (range 0 to 100).
-    /// 100 represetns fully charged, 0 represents fully discharged.
+    /// 100 represents fully charged, 0 represents fully discharged.
     /// All other values are reserved.
     @Characteristic(id: "2A19", notify: true)
     public var batteryLevel: UInt8?

--- a/Sources/BluetoothServices/Services/BloodPressureService.swift
+++ b/Sources/BluetoothServices/Services/BloodPressureService.swift
@@ -29,7 +29,7 @@ public final class BloodPressureService: BluetoothService, @unchecked Sendable {
     @Characteristic(id: "2A49", notify: true)
     public var features: BloodPressureFeature?
 
-    /// Receive intermdaite cuff pressure.
+    /// Receive intermediate cuff pressure.
     ///
     /// - Note: This characteristic is optional and notify-only.
     @Characteristic(id: "2A36", notify: true)

--- a/Sources/BluetoothServices/Services/CurrentTimeService.swift
+++ b/Sources/BluetoothServices/Services/CurrentTimeService.swift
@@ -1,0 +1,39 @@
+//
+// This source file is part of the Stanford Spezi open-source project
+//
+// SPDX-FileCopyrightText: 2024 Stanford University and the project authors (see CONTRIBUTORS.md)
+//
+// SPDX-License-Identifier: MIT
+//
+
+import class CoreBluetooth.CBUUID
+import SpeziBluetooth
+
+
+/// Bluetooth Current Time Service implementation.
+///
+/// This class partially implements the Bluetooth [Current Time Service 1.1](https://www.bluetooth.com/specifications/specs/current-time-service-1-1).
+/// - Note: The Local Time Information and Reference Time Information characteristics are currently not implemented.
+///     Both are optional to implement for peripherals.
+public final class CurrentTimeService: BluetoothService, @unchecked Sendable {
+    public static let id = CBUUID(string: "1805")
+
+
+    /// The current time and reason for adjustment.
+    ///
+    /// The characteristic can be used to read or modify the current time of the peripheral.
+    ///
+    /// - Note: This characteristic is required for this service. It is required to have
+    ///     _read_ and _notify_ properties and optionally _write_ property.
+    ///
+    /// During read and notify operations, the characteristics values are derived from the local date and time
+    /// of the peripheral. During a write operation, the peripheral may uses the information to set its local time.
+    ///
+    /// - Note: The peripheral may choose to ignore fields of the current time during writes. In this case
+    ///     it may return the error code 0x80 _Data field ignored_.
+    @Characteristic(id: "2A2B", notify: true)
+    public var currentTime: CurrentTime?
+
+
+    public init() {}
+}


### PR DESCRIPTION
# Add support for the Current Time Service

## :recycle: Current situation & Problem
The current time service is expoed by peripherals that have a sense of time (e.g., to display to the user or to, e.g., include the current timestamp within measurements). For example, Omron blood pressure cuffs implement the Current Time Service with a writeable Current Time characteristic. Only if you write to the peripherals current time, it would be able to include the timestamp of a blood pressure measurement.


## :gear: Release Notes 
* Add initial support for the Current Time Service
* Add `CurrentTime` characteristic.
* Add `ExactTime256` characteristic.
* Add `DayDateTime` characteristic.
* Add `DayOfWeek` characteristic.


## :books: Documentation
DocC bundle structure was updated to reflect these latest changes.


## :white_check_mark: Testing
Unit tests were added for new functionality.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
