### PR TITLE
Fix WeightScaleFeature initializer

### DIFF
--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -196,8 +196,8 @@ public struct WeightScaleFeature: OptionSet {
     ///   - weightResolution: The resolution for weight values for a ``WeightMeasurement``.
     ///   - heightResolution: The resolution for height values for a ``WeightMeasurement``.
     ///   - options: Additional flags and options of ``WeightScaleFeature`` (e.g., BMI support or multi user support).
-    public init(weightResolution: WeightResolution, heightResolution: HeightResolution, options: WeightScaleFeature...) {
-        let rawValue = (UInt32(weightResolution.rawValue) << 3) & (UInt32(heightResolution.rawValue) << 7)
+    public init(weightResolution: WeightResolution, heightResolution: HeightResolution = .unspecified, options: WeightScaleFeature...) {
+        let rawValue = (UInt32(weightResolution.rawValue) << 3) | (UInt32(heightResolution.rawValue) << 7)
         self = WeightScaleFeature(rawValue: rawValue).union(WeightScaleFeature(options))
     }
 }

--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -197,6 +197,7 @@ public struct WeightScaleFeature: OptionSet {
     ///   - heightResolution: The resolution for height values for a ``WeightMeasurement``.
     ///   - options: Additional flags and options of ``WeightScaleFeature`` (e.g., BMI support or multi user support).
     public init(weightResolution: WeightResolution, heightResolution: HeightResolution = .unspecified, options: WeightScaleFeature...) {
+        // swiftlint:disable:previous function_default_parameter_at_end
         let rawValue = (UInt32(weightResolution.rawValue) << 3) | (UInt32(heightResolution.rawValue) << 7)
         self = WeightScaleFeature(rawValue: rawValue).union(WeightScaleFeature(options))
     }

--- a/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
+++ b/Tests/SpeziBluetoothTests/BluetoothServicesCodingTests.swift
@@ -251,6 +251,13 @@ final class BluetoothServicesTests: XCTestCase {
             options: .bmiSupported,
             .multipleUsersSupported
         ))
+
+        let features2 = WeightScaleFeature(weightResolution: .resolution20g, heightResolution: .resolution5mm, options: .bmiSupported)
+        XCTAssertEqual(features2.weightResolution, .resolution20g)
+        XCTAssertEqual(features2.heightResolution, .resolution5mm)
+        XCTAssertTrue(features2.contains(.bmiSupported))
+        XCTAssertFalse(features2.contains(.multipleUsersSupported))
+        XCTAssertFalse(features2.contains(.timeStampSupported))
     }
 
     func testTemperatureType() throws {


### PR DESCRIPTION
# Fix WeightScaleFeature initializer

## :recycle: Current situation & Problem
The convenience initializer for the `WeightScaleFeature` initializer where both weight and height resolutions were not properly set. Unit tests didn't properly test for that case.
This was fixed in this PR.


## :gear: Release Notes 
* Made height resolution optional as it might not be supported at all.
* Fixed functionality of `WeightScaleFeature` initializer and added unit tests


## :books: Documentation
--


## :white_check_mark: Testing
Regression tests were added.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
