### PR TITLE
Inject Bluetooth Devices as Spezi Modules

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.4"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.2.0"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/dynamic-module-loading"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFileFormats", from: "1.2.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -26,7 +26,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.4"),
-        .package(url: "https://github.com/StanfordSpezi/Spezi", branch: "feature/dynamic-module-loading"),
+        .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.3.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziFileFormats", from: "1.2.0"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),

--- a/README.md
+++ b/README.md
@@ -197,6 +197,43 @@ struct MyView: View {
 }
 ```
 
+### Integration with Spezi Modules
+
+A Spezi [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module) is a great way of structuring your application into
+different subsystems and provides extensive capabilities to model relationship and dependence between modules.
+Every [`BluetoothDevice`](https://swiftpackageindex.com/stanfordspezi/spezibluetooth/documentation/spezibluetooth/bluetoothdevice) is a `Module`.
+Therefore, you can easily access your SpeziBluetooth device from within any Spezi `Module` using the standard
+[Module Dependency](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency) infrastructure. At the same time,
+every `BluetoothDevice` can benefit from the same capabilities as every other Spezi `Module`.
+
+Below is a short code example demonstrating how a `BluetoothDevice` uses the `@Dependency` property to interact with a Spezi Module that is
+configured within the Spezi application.
+
+```swift
+class Measurements: Module, EnvironmentAccessible, DefaultInitializable {
+    required init() {}
+
+    func recordNewMeasurement(_ measurement: WeightMeasurement) {
+        // ... process measurement
+    }
+}
+
+class MyDevice: BluetoothDevice {
+    @Service var weightScale = WeightScaleService()
+    
+    // declare dependency to a configured Spezi Module
+    @Dependency var measurements: Measurements
+    
+    required init() {
+        weightScale.$weightMeasurement.onChange(perform: handleNewMeasurement)
+    }
+    
+    private func handleNewMeasurement(_ measurement: WeightMeasurement) {
+        measurements.recordNewMeasurement(measurement)
+    }
+}
+```
+
 For more information, please refer to the [API documentation](https://swiftpackageindex.com/StanfordSpezi/SpeziBluetooth/documentation).
 
 

--- a/Sources/SpeziBluetooth/Bluetooth.swift
+++ b/Sources/SpeziBluetooth/Bluetooth.swift
@@ -144,6 +144,43 @@ import Spezi
 /// }
 /// ```
 ///
+/// ### Integration with Spezi Modules
+///
+/// A Spezi [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module) is a great way of structuring your application into
+/// different subsystems and provides extensive capabilities to model relationship and dependence between modules.
+/// Every ``BluetoothDevice`` is a `Module`.
+/// Therefore, you can easily access your SpeziBluetooth device from within any Spezi `Module` using the standard
+/// [Module Dependency](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency) infrastructure. At the same time,
+/// every `BluetoothDevice` can benefit from the same capabilities as every other Spezi `Module`.
+///
+/// Below is a short code example demonstrating how a `BluetoothDevice` uses the `@Dependency` property to interact with a Spezi Module that is
+/// configured within the Spezi application.
+///
+/// ```swift
+/// class Measurements: Module, EnvironmentAccessible, DefaultInitializable {
+///     required init() {}
+///
+///     func recordNewMeasurement(_ measurement: WeightMeasurement) {
+///         // ... process measurement
+///     }
+/// }
+///
+/// class MyDevice: BluetoothDevice {
+///     @Service var weightScale = WeightScaleService()
+///
+///     // declare dependency to a configured Spezi Module
+///     @Dependency var measurements: Measurements
+///
+///     required init() {
+///         weightScale.$weightMeasurement.onChange(perform: handleNewMeasurement)
+///     }
+///
+///     private func handleNewMeasurement(_ measurement: WeightMeasurement) {
+///         measurements.recordNewMeasurement(measurement)
+///     }
+/// }
+/// ```
+///
 /// ## Topics
 ///
 /// ### Configure the Bluetooth Module

--- a/Sources/SpeziBluetooth/Model/BluetoothDevice.swift
+++ b/Sources/SpeziBluetooth/Model/BluetoothDevice.swift
@@ -28,7 +28,7 @@ import Spezi
 ///     init() {}
 /// }
 /// ```
-public protocol BluetoothDevice: AnyObject, EnvironmentAccessible {
+public protocol BluetoothDevice: AnyObject, Module, EnvironmentAccessible {
     /// Initializes the Bluetooth Device.
     ///
     /// This initializer is called automatically when a peripheral of this type connects.

--- a/Sources/SpeziBluetooth/Model/BluetoothDevice.swift
+++ b/Sources/SpeziBluetooth/Model/BluetoothDevice.swift
@@ -28,7 +28,7 @@ import Spezi
 ///     init() {}
 /// }
 /// ```
-public protocol BluetoothDevice: AnyObject, Module, EnvironmentAccessible {
+public protocol BluetoothDevice: AnyObject, Module, Observable {
     /// Initializes the Bluetooth Device.
     ///
     /// This initializer is called automatically when a peripheral of this type connects.

--- a/Sources/SpeziBluetooth/Model/SemanticModel/DeviceDescriptionParser.swift
+++ b/Sources/SpeziBluetooth/Model/SemanticModel/DeviceDescriptionParser.swift
@@ -41,7 +41,7 @@ extension DiscoveryConfiguration {
 
 
 extension Set where Element == DiscoveryConfiguration {
-    var deviceTypes: [BluetoothDevice.Type] {
+    var deviceTypes: [any BluetoothDevice.Type] {
         map { configuration in
             configuration.anyDeviceType
         }

--- a/Sources/SpeziBluetooth/Modifier/ConnectedDevicesEnvironmentModifier.swift
+++ b/Sources/SpeziBluetooth/Modifier/ConnectedDevicesEnvironmentModifier.swift
@@ -27,13 +27,13 @@ private struct ConnectedDeviceEnvironmentModifier<Device: BluetoothDevice>: View
 
 
 struct ConnectedDevicesEnvironmentModifier: ViewModifier {
-    private let configuredDeviceTypes: [BluetoothDevice.Type]
+    private let configuredDeviceTypes: [any BluetoothDevice.Type]
 
     @Environment(ConnectedDevices.self)
     var connectedDevices
 
 
-    init(configuredDeviceTypes: [BluetoothDevice.Type]) {
+    init(configuredDeviceTypes: [any BluetoothDevice.Type]) {
         self.configuredDeviceTypes = configuredDeviceTypes
     }
 

--- a/Sources/SpeziBluetooth/SpeziBluetooth.docc/SpeziBluetooth.md
+++ b/Sources/SpeziBluetooth/SpeziBluetooth.docc/SpeziBluetooth.md
@@ -188,6 +188,43 @@ struct MyView: View {
 }
 ```
 
+### Integration with Spezi Modules
+
+A Spezi [`Module`](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module) is a great way of structuring your application into
+different subsystems and provides extensive capabilities to model relationship and dependence between modules.
+Every ``BluetoothDevice`` is a `Module`.
+Therefore, you can easily access your SpeziBluetooth device from within any Spezi `Module` using the standard
+[Module Dependency](https://swiftpackageindex.com/stanfordspezi/spezi/documentation/spezi/module-dependency) infrastructure. At the same time,
+every `BluetoothDevice` can benefit from the same capabilities as every other Spezi `Module`.
+
+Below is a short code example demonstrating how a `BluetoothDevice` uses the `@Dependency` property to interact with a Spezi Module that is
+configured within the Spezi application.
+
+```swift
+class Measurements: Module, EnvironmentAccessible, DefaultInitializable {
+    required init() {}
+
+    func recordNewMeasurement(_ measurement: WeightMeasurement) {
+        // ... process measurement
+    }
+}
+
+class MyDevice: BluetoothDevice {
+    @Service var weightScale = WeightScaleService()
+    
+    // declare dependency to a configured Spezi Module
+    @Dependency var measurements: Measurements
+    
+    required init() {
+        weightScale.$weightMeasurement.onChange(perform: handleNewMeasurement)
+    }
+    
+    private func handleNewMeasurement(_ measurement: WeightMeasurement) {
+        measurements.recordNewMeasurement(measurement)
+    }
+}
+```
+
 ### Thread Model
 
 Every instance of ``BluetoothManager`` (or ``Bluetooth``) creates an `SerialExecutor` to dispatch any Bluetooth related action.

--- a/Sources/SpeziBluetooth/Utils/ConnectedDevices.swift
+++ b/Sources/SpeziBluetooth/Utils/ConnectedDevices.swift
@@ -12,14 +12,12 @@ import Foundation
 @Observable
 class ConnectedDevices {
     /// We track the first connected device for every BluetoothDevice type.
-    @MainActor private var connectedDevices: [ObjectIdentifier: BluetoothDevice] = [:]
+    @MainActor private var connectedDevices: [ObjectIdentifier: any BluetoothDevice] = [:]
     @MainActor private var connectedDeviceIds: [ObjectIdentifier: UUID] = [:]
-
-    var hasConnectedDevices = false
 
 
     @MainActor
-    func update(with devices: [UUID: BluetoothDevice]) {
+    func update(with devices: [UUID: any BluetoothDevice]) {
         // remove devices that disconnected
         for (identifier, uuid) in connectedDeviceIds where devices[uuid] == nil {
             connectedDeviceIds.removeValue(forKey: identifier)
@@ -36,12 +34,10 @@ class ConnectedDevices {
             connectedDevices[device.typeIdentifier] = device
             connectedDeviceIds[device.typeIdentifier] = uuid
         }
-
-        hasConnectedDevices = !connectedDevices.isEmpty
     }
 
     @MainActor
-    subscript(_ identifier: ObjectIdentifier) -> BluetoothDevice? {
+    subscript(_ identifier: ObjectIdentifier) -> (any BluetoothDevice)? {
         connectedDevices[identifier]
     }
 }


### PR DESCRIPTION
# Inject Bluetooth Devices as Spezi Modules

## :recycle: Current situation & Problem

`BluetoothDevice`s were previously inaccessible from Spezi `Module`s without additional infrastructure. https://github.com/StanfordSpezi/Spezi/pull/105 introduced functionality to dynamically load and unload Modules from the Spezi module systems. We use that new infrastructure to make every `BluetoohtDevice` to be a Spezi Module.
This allows every `BluetoothDevice` to use the same functionality available to Spezi Modules. Further, Spezi Modules can seamlessly interact with `BluetoothDevice` as well.

## :gear: Release Notes 
* `BluetoothDevice`s are now Spezi `Module`s.


## :books: Documentation
Additional documentation section was added.


## :white_check_mark: Testing
Verified in Engage.


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
