### PR TITLE
Migrate to SpeziNetworking 2.0

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
     dependencies: [
         .package(url: "https://github.com/StanfordSpezi/SpeziFoundation", from: "1.0.4"),
         .package(url: "https://github.com/StanfordSpezi/Spezi", from: "1.3.0"),
-        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "1.0.0"),
+        .package(url: "https://github.com/StanfordSpezi/SpeziNetworking", from: "2.0.1"),
         .package(url: "https://github.com/StanfordSpezi/SpeziViews", from: "1.3.0"),
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.59.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.4")

--- a/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureFeature.swift
@@ -68,14 +68,14 @@ extension BloodPressureFeature: Hashable, Sendable {}
 
 
 extension BloodPressureFeature: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt16(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/BloodPressureMeasurement.swift
@@ -145,39 +145,39 @@ extension BloodPressureMeasurement: Sendable, Hashable {}
 
 
 extension BloodPressureMeasurement.Flags: ByteCodable {
-    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension BloodPressureMeasurement.Status: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt16(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension BloodPressureMeasurement: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
-              let systolicValue = MedFloat16(from: &byteBuffer, preferredEndianness: endianness),
-              let diastolicValue = MedFloat16(from: &byteBuffer, preferredEndianness: endianness),
-              let meanArterialPressure = MedFloat16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let flags = Flags(from: &byteBuffer),
+              let systolicValue = MedFloat16(from: &byteBuffer),
+              let diastolicValue = MedFloat16(from: &byteBuffer),
+              let meanArterialPressure = MedFloat16(from: &byteBuffer) else {
             return nil
         }
 
@@ -192,7 +192,7 @@ extension BloodPressureMeasurement: ByteCodable {
         }
 
         if flags.contains(.timeStampPresent) {
-            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let timeStamp = DateTime(from: &byteBuffer) else {
                 return nil
             }
             self.timeStamp = timeStamp
@@ -201,7 +201,7 @@ extension BloodPressureMeasurement: ByteCodable {
         }
 
         if flags.contains(.pulseRatePresent) {
-            guard let pulseRate = MedFloat16(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let pulseRate = MedFloat16(from: &byteBuffer) else {
                 return nil
             }
             self.pulseRate = pulseRate
@@ -210,7 +210,7 @@ extension BloodPressureMeasurement: ByteCodable {
         }
 
         if flags.contains(.userIdPresent) {
-            guard let userId = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let userId = UInt8(from: &byteBuffer) else {
                 return nil
             }
             self.userId = userId
@@ -219,7 +219,7 @@ extension BloodPressureMeasurement: ByteCodable {
         }
 
         if flags.contains(.measurementStatusPresent) {
-            guard let status = Status(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let status = Status(from: &byteBuffer) else {
                 return nil
             }
             self.measurementStatus = status
@@ -228,16 +228,16 @@ extension BloodPressureMeasurement: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         var flags: Flags = []
 
         // write empty flags field for now to move writer index
         let flagsIndex = byteBuffer.writerIndex
-        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
+        flags.encode(to: &byteBuffer)
 
-        systolicValue.encode(to: &byteBuffer, preferredEndianness: endianness)
-        diastolicValue.encode(to: &byteBuffer, preferredEndianness: endianness)
-        meanArterialPressure.encode(to: &byteBuffer, preferredEndianness: endianness)
+        systolicValue.encode(to: &byteBuffer)
+        diastolicValue.encode(to: &byteBuffer)
+        meanArterialPressure.encode(to: &byteBuffer)
 
         if case .kPa = unit {
             flags.insert(.kPaUnit)
@@ -245,22 +245,22 @@ extension BloodPressureMeasurement: ByteCodable {
 
         if let timeStamp {
             flags.insert(.timeStampPresent)
-            timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
+            timeStamp.encode(to: &byteBuffer)
         }
 
         if let pulseRate {
             flags.insert(.pulseRatePresent)
-            pulseRate.encode(to: &byteBuffer, preferredEndianness: endianness)
+            pulseRate.encode(to: &byteBuffer)
         }
 
         if let userId {
             flags.insert(.userIdPresent)
-            userId.encode(to: &byteBuffer, preferredEndianness: endianness)
+            userId.encode(to: &byteBuffer)
         }
 
         if let measurementStatus {
             flags.insert(.measurementStatusPresent)
-            measurementStatus.encode(to: &byteBuffer, preferredEndianness: endianness)
+            measurementStatus.encode(to: &byteBuffer)
         }
 
         byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field

--- a/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
+++ b/Sources/BluetoothServices/Characteristics/IntermediateCuffPressure.swift
@@ -114,15 +114,15 @@ extension IntermediateCuffPressure: Hashable, Sendable {
 
 
 extension IntermediateCuffPressure: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let representation = BloodPressureMeasurement(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let representation = BloodPressureMeasurement(from: &byteBuffer) else {
             return nil
         }
 
         self.representation = representation
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        representation.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        representation.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/MeasurementInterval.swift
+++ b/Sources/BluetoothServices/Characteristics/MeasurementInterval.swift
@@ -46,15 +46,15 @@ extension MeasurementInterval: RawRepresentable {
 
 
 extension MeasurementInterval: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let value = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let value = UInt16(from: &byteBuffer) else {
             return nil
         }
 
         self.init(rawValue: value)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/PnPID.swift
+++ b/Sources/BluetoothServices/Characteristics/PnPID.swift
@@ -97,36 +97,36 @@ extension VendorIDSource: RawRepresentable {
 
 
 extension VendorIDSource: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let source = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let source = UInt8(from: &byteBuffer) else {
             return nil
         }
 
         self.init(rawValue: source)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension PnPID: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let vendorIdSource = VendorIDSource(from: &byteBuffer, preferredEndianness: endianness),
-              let vendorId = UInt16(from: &byteBuffer, preferredEndianness: endianness),
-              let productId = UInt16(from: &byteBuffer, preferredEndianness: endianness),
-              let productVersion = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let vendorIdSource = VendorIDSource(from: &byteBuffer),
+              let vendorId = UInt16(from: &byteBuffer),
+              let productId = UInt16(from: &byteBuffer),
+              let productVersion = UInt16(from: &byteBuffer) else {
             return nil
         }
 
         self.init(vendorIdSource: vendorIdSource, vendorId: vendorId, productId: productId, productVersion: productVersion)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        vendorIdSource.encode(to: &byteBuffer, preferredEndianness: endianness)
-        vendorId.encode(to: &byteBuffer, preferredEndianness: endianness)
-        productId.encode(to: &byteBuffer, preferredEndianness: endianness)
-        productVersion.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        vendorIdSource.encode(to: &byteBuffer)
+        vendorId.encode(to: &byteBuffer)
+        productId.encode(to: &byteBuffer)
+        productVersion.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessFilterCriteria.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessFilterCriteria.swift
@@ -61,19 +61,19 @@ extension RecordAccessRangeFilterCriteria: Hashable, Sendable {}
 
 
 extension RecordAccessFilterCriteria: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let filterType = RecordAccessFilterType(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let filterType = RecordAccessFilterType(from: &byteBuffer) else {
             return nil
         }
 
         switch filterType {
         case .sequenceNumber:
-            guard let value = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let value = UInt16(from: &byteBuffer) else {
                 return nil
             }
             self = .sequenceNumber(value)
         case .userFacingTime:
-            guard let value = Int16(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let value = Int16(from: &byteBuffer) else {
                 return nil
             }
             self = .userFacingTime(value)
@@ -82,35 +82,35 @@ extension RecordAccessFilterCriteria: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        filterType.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        filterType.encode(to: &byteBuffer)
 
         switch self {
         case let .sequenceNumber(value):
-            value.encode(to: &byteBuffer, preferredEndianness: endianness)
+            value.encode(to: &byteBuffer)
         case let .userFacingTime(value):
-            value.encode(to: &byteBuffer, preferredEndianness: endianness)
+            value.encode(to: &byteBuffer)
         }
     }
 }
 
 
 extension RecordAccessRangeFilterCriteria: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let filterType = RecordAccessFilterType(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let filterType = RecordAccessFilterType(from: &byteBuffer) else {
             return nil
         }
 
         switch filterType {
         case .sequenceNumber:
-            guard let min = UInt16(from: &byteBuffer, preferredEndianness: endianness),
-                  let max = UInt16(from: &byteBuffer, preferredEndianness: endianness)else {
+            guard let min = UInt16(from: &byteBuffer),
+                  let max = UInt16(from: &byteBuffer) else {
                 return nil
             }
             self = .sequenceNumber(min: min, max: max)
         case .userFacingTime:
-            guard let min = Int16(from: &byteBuffer, preferredEndianness: endianness),
-                  let max = Int16(from: &byteBuffer, preferredEndianness: endianness)else {
+            guard let min = Int16(from: &byteBuffer),
+                  let max = Int16(from: &byteBuffer) else {
                 return nil
             }
             self = .userFacingTime(min: min, max: max)
@@ -119,16 +119,16 @@ extension RecordAccessRangeFilterCriteria: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        filterType.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        filterType.encode(to: &byteBuffer)
 
         switch self {
         case let .sequenceNumber(min, max):
-            min.encode(to: &byteBuffer, preferredEndianness: endianness)
-            max.encode(to: &byteBuffer, preferredEndianness: endianness)
+            min.encode(to: &byteBuffer)
+            max.encode(to: &byteBuffer)
         case let .userFacingTime(min, max):
-            min.encode(to: &byteBuffer, preferredEndianness: endianness)
-            max.encode(to: &byteBuffer, preferredEndianness: endianness)
+            min.encode(to: &byteBuffer)
+            max.encode(to: &byteBuffer)
         }
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessFilterType.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessFilterType.swift
@@ -41,14 +41,14 @@ extension RecordAccessFilterType: Hashable, Sendable {}
 
 
 extension RecordAccessFilterType: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessGeneralResponse.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessGeneralResponse.swift
@@ -36,17 +36,17 @@ extension RecordAccessGeneralResponse: Hashable, Sendable {}
 
 
 extension RecordAccessGeneralResponse: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let requestOpCode = RecordAccessOpCode(from: &byteBuffer, preferredEndianness: endianness),
-              let response = RecordAccessResponseCode(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let requestOpCode = RecordAccessOpCode(from: &byteBuffer),
+              let response = RecordAccessResponseCode(from: &byteBuffer) else {
             return nil
         }
 
         self.init(requestOpCode: requestOpCode, response: response)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        requestOpCode.encode(to: &byteBuffer, preferredEndianness: endianness)
-        response.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        requestOpCode.encode(to: &byteBuffer)
+        response.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessGenericOperand.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/GenericOperand/RecordAccessGenericOperand.swift
@@ -58,25 +58,24 @@ extension RecordAccessGenericOperand: RecordAccessOperand {
 
     public init?( // swiftlint:disable:this cyclomatic_complexity
         from byteBuffer: inout ByteBuffer,
-        preferredEndianness endianness: Endianness,
         opCode: RecordAccessOpCode,
         operator: RecordAccessOperator
     ) {
         switch opCode {
         case .responseCode:
-            guard let response = RecordAccessGeneralResponse(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let response = RecordAccessGeneralResponse(from: &byteBuffer) else {
                 return nil
             }
             self = .generalResponse(response)
         case .reportStoredRecords, .deleteStoredRecords, .reportNumberOfStoredRecords:
             switch `operator` {
             case .lessThanOrEqualTo, .greaterThanOrEqual:
-                guard let filterCriteria = RecordAccessFilterCriteria(from: &byteBuffer, preferredEndianness: endianness) else {
+                guard let filterCriteria = RecordAccessFilterCriteria(from: &byteBuffer) else {
                     return nil
                 }
                 self = .filterCriteria(filterCriteria)
             case .withinInclusiveRangeOf:
-                guard let filterCriteria = RecordAccessRangeFilterCriteria(from: &byteBuffer, preferredEndianness: endianness) else {
+                guard let filterCriteria = RecordAccessRangeFilterCriteria(from: &byteBuffer) else {
                     return nil
                 }
                 self = .rangeFilterCriteria(filterCriteria)
@@ -84,7 +83,7 @@ extension RecordAccessGenericOperand: RecordAccessOperand {
                 return nil
             }
         case .numberOfStoredRecordsResponse:
-            guard let count = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let count = UInt16(from: &byteBuffer) else {
                 return nil
             }
             self = .numberOfRecords(count)
@@ -93,16 +92,16 @@ extension RecordAccessGenericOperand: RecordAccessOperand {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         switch self {
         case let .generalResponse(response):
-            response.encode(to: &byteBuffer, preferredEndianness: endianness)
+            response.encode(to: &byteBuffer)
         case let .filterCriteria(criteria):
-            criteria.encode(to: &byteBuffer, preferredEndianness: endianness)
+            criteria.encode(to: &byteBuffer)
         case let .rangeFilterCriteria(criteria):
-            criteria.encode(to: &byteBuffer, preferredEndianness: endianness)
+            criteria.encode(to: &byteBuffer)
         case let .numberOfRecords(value):
-            value.encode(to: &byteBuffer, preferredEndianness: endianness)
+            value.encode(to: &byteBuffer)
         }
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessControlPoint.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessControlPoint.swift
@@ -79,9 +79,9 @@ extension RecordAccessControlPoint: ControlPointCharacteristic {}
 
 
 extension RecordAccessControlPoint: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let opCode = RecordAccessOpCode(from: &byteBuffer, preferredEndianness: endianness),
-              let `operator` = RecordAccessOperator(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let opCode = RecordAccessOpCode(from: &byteBuffer),
+              let `operator` = RecordAccessOperator(from: &byteBuffer) else {
             return nil
         }
 
@@ -89,15 +89,15 @@ extension RecordAccessControlPoint: ByteCodable {
         // If an operand is required is dependent on the op code and operator.
         // This might be implementation specific (e.g., custom op codes). Therefore, we can't enforce anything here.
         // The receiver would need to unwrap the optional anyways.
-        let operand = Operand(from: &byteBuffer, preferredEndianness: endianness, opCode: opCode, operator: `operator`)
+        let operand = Operand(from: &byteBuffer, opCode: opCode, operator: `operator`)
 
         self.init(opCode: opCode, operator: `operator`, operand: operand)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        opCode.encode(to: &byteBuffer, preferredEndianness: endianness)
-        `operator`.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        opCode.encode(to: &byteBuffer)
+        `operator`.encode(to: &byteBuffer)
 
-        operand?.encode(to: &byteBuffer, preferredEndianness: endianness)
+        operand?.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOpCode.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOpCode.swift
@@ -92,14 +92,14 @@ extension RecordAccessOpCode: Hashable, Sendable {}
 
 
 extension RecordAccessOpCode: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOperand.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOperand.swift
@@ -38,13 +38,10 @@ public protocol RecordAccessOperand: ByteEncodable {
     ///
     /// - Parameters:
     ///   - byteBuffer: The ByteBuffer to read from.
-    ///   - endianness: The preferred endianness to use for decoding if applicable.
-    ///     This might not apply to certain data structures that operate on single byte level.
     ///   - opCode: The opcode of the ``RecordAccessControlPoint`` this operand is being decoded for.
     ///   - operator: The operator of the ``RecordAccessControlPoint`` this operand is being decoded for.
     init?(
         from byteBuffer: inout ByteBuffer,
-        preferredEndianness endianness: Endianness,
         opCode: RecordAccessOpCode,
         `operator`: RecordAccessOperator
     )

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOperator.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessOperator.swift
@@ -69,14 +69,14 @@ extension RecordAccessOperator: Hashable, Sendable {}
 
 
 extension RecordAccessOperator: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessResponseCode.swift
+++ b/Sources/BluetoothServices/Characteristics/RecordAccess/RecordAccessResponseCode.swift
@@ -72,14 +72,14 @@ extension RecordAccessResponseCode: Error {}
 
 
 extension RecordAccessResponseCode: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureMeasurement.swift
@@ -72,22 +72,22 @@ extension TemperatureMeasurement: Sendable, Hashable {}
 
 
 extension TemperatureMeasurement.Flags: ByteCodable {
-    init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 extension TemperatureMeasurement: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
-              let temperature = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let flags = Flags(from: &byteBuffer),
+              let temperature = UInt32(from: &byteBuffer) else {
             return nil
         }
 
@@ -100,7 +100,7 @@ extension TemperatureMeasurement: ByteCodable {
         }
 
         if flags.contains(.timeStampPresent) {
-            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let timeStamp = DateTime(from: &byteBuffer) else {
                 return nil
             }
             self.timeStamp = timeStamp
@@ -109,7 +109,7 @@ extension TemperatureMeasurement: ByteCodable {
         }
 
         if flags.contains(.temperatureTypePresent) {
-            guard let temperatureType = TemperatureType(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let temperatureType = TemperatureType(from: &byteBuffer) else {
                 return nil
             }
             self.temperatureType = temperatureType
@@ -118,14 +118,14 @@ extension TemperatureMeasurement: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         var flags: Flags = []
 
         // write empty flags field for now to move writer index
         let flagsIndex = byteBuffer.writerIndex
-        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
+        flags.encode(to: &byteBuffer)
 
-        temperature.encode(to: &byteBuffer, preferredEndianness: endianness)
+        temperature.encode(to: &byteBuffer)
 
         if case .fahrenheit = unit {
             flags.insert(.fahrenheitUnit)
@@ -133,12 +133,12 @@ extension TemperatureMeasurement: ByteCodable {
 
         if let timeStamp {
             flags.insert(.timeStampPresent)
-            timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
+            timeStamp.encode(to: &byteBuffer)
         }
 
         if let temperatureType {
             flags.insert(.temperatureTypePresent)
-            temperatureType.encode(to: &byteBuffer, preferredEndianness: endianness)
+            temperatureType.encode(to: &byteBuffer)
         }
 
         byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field

--- a/Sources/BluetoothServices/Characteristics/TemperatureType.swift
+++ b/Sources/BluetoothServices/Characteristics/TemperatureType.swift
@@ -41,15 +41,15 @@ extension TemperatureType: Hashable, Sendable {}
 
 
 extension TemperatureType: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let value = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let value = UInt8(from: &byteBuffer) else {
             return nil
         }
 
         self.init(rawValue: value)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/Time/CurrentTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/CurrentTime.swift
@@ -59,31 +59,31 @@ extension CurrentTime: Hashable, Sendable {}
 
 
 extension CurrentTime.AdjustReason: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension CurrentTime: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let time = ExactTime256(from: &byteBuffer, preferredEndianness: endianness),
-              let adjustReason = AdjustReason(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let time = ExactTime256(from: &byteBuffer),
+              let adjustReason = AdjustReason(from: &byteBuffer) else {
             return nil
         }
 
         self.init(time: time, adjustReason: adjustReason)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        time.encode(to: &byteBuffer, preferredEndianness: endianness)
-        adjustReason.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        time.encode(to: &byteBuffer)
+        adjustReason.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/Time/DateTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DateTime.swift
@@ -177,40 +177,40 @@ extension DateTime: Hashable, Sendable {}
 
 
 extension DateTime.Month: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let value = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let value = UInt8(from: &byteBuffer) else {
             return nil
         }
 
         self.init(rawValue: value)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension DateTime: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let year = UInt16(from: &byteBuffer, preferredEndianness: endianness),
-              let month = Month(from: &byteBuffer, preferredEndianness: endianness),
-              let day = UInt8(from: &byteBuffer, preferredEndianness: endianness),
-              let hours = UInt8(from: &byteBuffer, preferredEndianness: endianness),
-              let minutes = UInt8(from: &byteBuffer, preferredEndianness: endianness),
-              let seconds = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let year = UInt16(from: &byteBuffer),
+              let month = Month(from: &byteBuffer),
+              let day = UInt8(from: &byteBuffer),
+              let hours = UInt8(from: &byteBuffer),
+              let minutes = UInt8(from: &byteBuffer),
+              let seconds = UInt8(from: &byteBuffer) else {
             return nil
         }
 
         self.init(year: year, month: month, day: day, hours: hours, minutes: minutes, seconds: seconds)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        year.encode(to: &byteBuffer, preferredEndianness: endianness)
-        month.encode(to: &byteBuffer, preferredEndianness: endianness)
-        day.encode(to: &byteBuffer, preferredEndianness: endianness)
-        hours.encode(to: &byteBuffer, preferredEndianness: endianness)
-        minutes.encode(to: &byteBuffer, preferredEndianness: endianness)
-        seconds.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        year.encode(to: &byteBuffer)
+        month.encode(to: &byteBuffer)
+        day.encode(to: &byteBuffer)
+        hours.encode(to: &byteBuffer)
+        minutes.encode(to: &byteBuffer)
+        seconds.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/Time/DayDateTime.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DayDateTime.swift
@@ -97,9 +97,9 @@ extension DayDateTime: Hashable, Sendable {}
 
 
 extension DayDateTime: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let dateTime = DateTime(from: &byteBuffer, preferredEndianness: endianness),
-              let dayOfWeek = DayOfWeek(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let dateTime = DateTime(from: &byteBuffer),
+              let dayOfWeek = DayOfWeek(from: &byteBuffer) else {
             return nil
         }
 
@@ -107,8 +107,8 @@ extension DayDateTime: ByteCodable {
     }
 
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        dateTime.encode(to: &byteBuffer, preferredEndianness: endianness)
-        dayOfWeek.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        dateTime.encode(to: &byteBuffer)
+        dayOfWeek.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/Time/DayOfWeek.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/DayOfWeek.swift
@@ -54,14 +54,14 @@ extension DayOfWeek: Hashable, Sendable {}
 
 
 extension DayOfWeek: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/Time/ExactTime256.swift
+++ b/Sources/BluetoothServices/Characteristics/Time/ExactTime256.swift
@@ -119,17 +119,17 @@ extension ExactTime256: Hashable, Sendable {}
 
 
 extension ExactTime256: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let dayDateTime = DayDateTime(from: &byteBuffer, preferredEndianness: endianness),
-              let fractions256 = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let dayDateTime = DayDateTime(from: &byteBuffer),
+              let fractions256 = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(dayDateTime: dayDateTime, fractions256: fractions256)
     }
 
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        dayDateTime.encode(to: &byteBuffer, preferredEndianness: endianness)
-        fractions256.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        dayDateTime.encode(to: &byteBuffer)
+        fractions256.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightMeasurement.swift
@@ -141,39 +141,39 @@ extension WeightMeasurement: Hashable, Sendable {}
 
 
 extension WeightMeasurement.Flags: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }
 
 
 extension WeightMeasurement.AdditionalInfo: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let bmi = UInt16(from: &byteBuffer, preferredEndianness: endianness),
-              let height = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let bmi = UInt16(from: &byteBuffer),
+              let height = UInt16(from: &byteBuffer) else {
             return nil
         }
         self.init(bmi: bmi, height: height)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        bmi.encode(to: &byteBuffer, preferredEndianness: endianness)
-        height.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        bmi.encode(to: &byteBuffer)
+        height.encode(to: &byteBuffer)
     }
 }
 
 
 extension WeightMeasurement: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let flags = Flags(from: &byteBuffer, preferredEndianness: endianness),
-              let weight = UInt16(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let flags = Flags(from: &byteBuffer),
+              let weight = UInt16(from: &byteBuffer) else {
             return nil
         }
 
@@ -186,7 +186,7 @@ extension WeightMeasurement: ByteCodable {
         }
 
         if flags.contains(.timeStampPresent) {
-            guard let timeStamp = DateTime(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let timeStamp = DateTime(from: &byteBuffer) else {
                 return nil
             }
             self.timeStamp = timeStamp
@@ -195,7 +195,7 @@ extension WeightMeasurement: ByteCodable {
         }
 
         if flags.contains(.userIdPresent) {
-            guard let userId = UInt8(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let userId = UInt8(from: &byteBuffer) else {
                 return nil
             }
             self.userId = userId
@@ -204,7 +204,7 @@ extension WeightMeasurement: ByteCodable {
         }
 
         if flags.contains(.bmiAndHeightPresent) {
-            guard let additionalInfo = AdditionalInfo(from: &byteBuffer, preferredEndianness: endianness) else {
+            guard let additionalInfo = AdditionalInfo(from: &byteBuffer) else {
                 return nil
             }
             self.additionalInfo = additionalInfo
@@ -213,28 +213,28 @@ extension WeightMeasurement: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
+    public func encode(to byteBuffer: inout ByteBuffer) {
         var flags: Flags = []
 
         // write empty flags field for now to move writer index
         let flagsIndex = byteBuffer.writerIndex
-        flags.encode(to: &byteBuffer, preferredEndianness: endianness)
+        flags.encode(to: &byteBuffer)
 
-        weight.encode(to: &byteBuffer, preferredEndianness: endianness)
+        weight.encode(to: &byteBuffer)
 
         if let timeStamp {
             flags.insert(.timeStampPresent)
-            timeStamp.encode(to: &byteBuffer, preferredEndianness: endianness)
+            timeStamp.encode(to: &byteBuffer)
         }
 
         if let userId {
             flags.insert(.userIdPresent)
-            userId.encode(to: &byteBuffer, preferredEndianness: endianness)
+            userId.encode(to: &byteBuffer)
         }
 
         if let additionalInfo {
             flags.insert(.bmiAndHeightPresent)
-            additionalInfo.encode(to: &byteBuffer, preferredEndianness: endianness)
+            additionalInfo.encode(to: &byteBuffer)
         }
 
         byteBuffer.setInteger(flags.rawValue, at: flagsIndex) // finally update the flags field

--- a/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
+++ b/Sources/BluetoothServices/Characteristics/WeightScaleFeature.swift
@@ -220,14 +220,14 @@ extension WeightScaleFeature: Hashable, Sendable {}
 
 
 extension WeightScaleFeature: ByteCodable {
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt32(from: &byteBuffer, preferredEndianness: endianness) else {
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt32(from: &byteBuffer) else {
             return nil
         }
         self.init(rawValue: rawValue)
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        rawValue.encode(to: &byteBuffer)
     }
 }

--- a/Sources/BluetoothServices/TestingSupport/EventLog.swift
+++ b/Sources/BluetoothServices/TestingSupport/EventLog.swift
@@ -79,8 +79,8 @@ extension EventLog: ByteCodable {
         }
     }
 
-    public init?(from byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        guard let rawValue = UInt8(from: &byteBuffer, preferredEndianness: endianness),
+    public init?(from byteBuffer: inout ByteBuffer) {
+        guard let rawValue = UInt8(from: &byteBuffer),
               let type = EventType(rawValue: rawValue) else {
             return nil
         }
@@ -115,19 +115,19 @@ extension EventLog: ByteCodable {
         }
     }
 
-    public func encode(to byteBuffer: inout ByteBuffer, preferredEndianness endianness: Endianness) {
-        type.rawValue.encode(to: &byteBuffer, preferredEndianness: endianness)
+    public func encode(to byteBuffer: inout ByteBuffer) {
+        type.rawValue.encode(to: &byteBuffer)
         switch self {
         case .none:
             break
         case let .subscribedToNotification(characteristic):
-            characteristic.data.encode(to: &byteBuffer, preferredEndianness: endianness)
+            characteristic.data.encode(to: &byteBuffer)
         case let .unsubscribedToNotification(characteristic):
-            characteristic.data.encode(to: &byteBuffer, preferredEndianness: endianness)
+            characteristic.data.encode(to: &byteBuffer)
         case let .receivedRead(characteristic):
-            characteristic.data.encode(to: &byteBuffer, preferredEndianness: endianness)
+            characteristic.data.encode(to: &byteBuffer)
         case let .receivedWrite(characteristic, value):
-            characteristic.data.encode(to: &byteBuffer, preferredEndianness: endianness)
+            characteristic.data.encode(to: &byteBuffer)
             byteBuffer.writeData(value)
         }
     }


### PR DESCRIPTION
# Migrate to SpeziNetworking 2.0

## :recycle: Current situation & Problem
This PR migrates SpeziBluetooth to use the newest release of ByteCoding as part of SpeziNetworking 2.0.


## :gear: Release Notes 
* Migrate to new SpeziNetworking 2.0 release.


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
