### PR TITLE
Update SPI file with latest targets

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -11,8 +11,6 @@ builder:
   configs:
     - platform: ios
       documentation_targets:
-      - BluetoothServices
-      - BluetoothViews
       - SpeziBluetooth
+      - SpeziBluetoothServices
       - TestPeripheral
-      - SpeziDevices


### PR DESCRIPTION
# Update SPI file with latest targets

## :recycle: Current situation & Problem
This PR fixes documentation deployment as target names are outdate din the `.spi.yml` file after merging #38.


## :gear: Release Notes 
- Fix SPI target names for documentation deployment.
## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
