### PR TITLE
Support `configure()` call on services and expose BluetoothScanner via APISupport SPI

### DIFF
--- a/Sources/SpeziBluetooth/Bluetooth.swift
+++ b/Sources/SpeziBluetooth/Bluetooth.swift
@@ -549,7 +549,6 @@ public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
         let device = prepareDevice(id: uuid, Device.self, peripheral: peripheral)
         // We load the module with external ownership. Meaning, Spezi won't keep any strong references to the Module and deallocation of
         // the module is possible, freeing all Spezi related resources.
-        let spezi = spezi
         await spezi.loadModule(device, ownership: .external)
 
         // The semantics of retrievePeripheral is as follows: it returns a BluetoothPeripheral that is weakly allocated by the BluetoothManager.´

--- a/Sources/SpeziBluetooth/Bluetooth.swift
+++ b/Sources/SpeziBluetooth/Bluetooth.swift
@@ -599,6 +599,7 @@ public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
 }
 
 
+@_spi(APISupport)
 extension Bluetooth: BluetoothScanner {
     /// Support for the auto connect modifier.
     @_documentation(visibility: internal)
@@ -607,7 +608,7 @@ extension Bluetooth: BluetoothScanner {
     }
 
     @SpeziBluetooth
-    func scanNearbyDevices(_ state: BluetoothModuleDiscoveryState) {
+    public func scanNearbyDevices(_ state: BluetoothModuleDiscoveryState) {
         scanNearbyDevices(
             minimumRSSI: state.minimumRSSI,
             advertisementStaleInterval: state.advertisementStaleInterval,
@@ -616,7 +617,7 @@ extension Bluetooth: BluetoothScanner {
     }
 
     @SpeziBluetooth
-    func updateScanningState(_ state: BluetoothModuleDiscoveryState) {
+    public func updateScanningState(_ state: BluetoothModuleDiscoveryState) {
         let managerState = BluetoothManagerDiscoveryState(
             configuredDevices: discoveryConfiguration,
             minimumRSSI: state.minimumRSSI,

--- a/Sources/SpeziBluetooth/CoreBluetooth/BluetoothManager.swift
+++ b/Sources/SpeziBluetooth/CoreBluetooth/BluetoothManager.swift
@@ -253,7 +253,8 @@ public class BluetoothManager: Observable, Sendable, Identifiable { // swiftlint
         scanNearbyDevices(state)
     }
 
-    func scanNearbyDevices(_ state: BluetoothManagerDiscoveryState) {
+    @_spi(APISupport)
+    public func scanNearbyDevices(_ state: BluetoothManagerDiscoveryState) {
         guard discoverySession == nil else {
             return // already scanning!
         }
@@ -534,6 +535,7 @@ public class BluetoothManager: Observable, Sendable, Identifiable { // swiftlint
 }
 
 
+@_spi(APISupport)
 extension BluetoothManager: BluetoothScanner {
     /// Default id based on `ObjectIdentifier`.
     public nonisolated var id: ObjectIdentifier {
@@ -550,7 +552,7 @@ extension BluetoothManager: BluetoothScanner {
         storage.hasConnectedDevices // support for DiscoverySession
     }
 
-    func updateScanningState(_ state: BluetoothManagerDiscoveryState) {
+    public func updateScanningState(_ state: BluetoothManagerDiscoveryState) {
         guard let discoverySession else {
             return
         }

--- a/Sources/SpeziBluetooth/CoreBluetooth/BluetoothPeripheral.swift
+++ b/Sources/SpeziBluetooth/CoreBluetooth/BluetoothPeripheral.swift
@@ -1005,7 +1005,7 @@ extension BluetoothPeripheral {
                     logger.warning("Received erroneous write response for \(characteristic.uuid) without an ongoing access: \(error)")
                 } else {
                     result = .success(())
-                    logger.debug("Characteristic write for \(characteristic.uuid) returned with error: \(error)")
+                    logger.debug("Characteristic write for \(characteristic.uuid) returned successfully.")
                 }
 
                 let didHandle = device.characteristicAccesses.resumeWrite(with: result, for: characteristic.cbObject)

--- a/Sources/SpeziBluetooth/CoreBluetooth/Model/DiscoverySession.swift
+++ b/Sources/SpeziBluetooth/CoreBluetooth/Model/DiscoverySession.swift
@@ -17,7 +17,8 @@ private func optionalMax<Value: Comparable>(_ lhs: Value?, _ rhs: Value?) -> Val
 }
 
 
-struct BluetoothManagerDiscoveryState: BluetoothScanningState {
+@_spi(APISupport)
+public struct BluetoothManagerDiscoveryState: BluetoothScanningState {
     /// The device descriptions describing how nearby devices are discovered.
     let configuredDevices: Set<DiscoveryDescription>
     /// The minimum rssi that is required for a device to be considered discovered.
@@ -35,7 +36,7 @@ struct BluetoothManagerDiscoveryState: BluetoothScanningState {
         self.autoConnect = autoConnect
     }
 
-    func merging(with other: BluetoothManagerDiscoveryState) -> BluetoothManagerDiscoveryState {
+    public func merging(with other: BluetoothManagerDiscoveryState) -> BluetoothManagerDiscoveryState {
         BluetoothManagerDiscoveryState(
             configuredDevices: configuredDevices.union(other.configuredDevices),
             minimumRSSI: optionalMax(minimumRSSI, other.minimumRSSI),
@@ -44,7 +45,7 @@ struct BluetoothManagerDiscoveryState: BluetoothScanningState {
         )
     }
 
-    func updateOptions(minimumRSSI: Int?, advertisementStaleInterval: TimeInterval?) -> BluetoothManagerDiscoveryState {
+    public func updateOptions(minimumRSSI: Int?, advertisementStaleInterval: TimeInterval?) -> BluetoothManagerDiscoveryState {
         BluetoothManagerDiscoveryState(
             configuredDevices: configuredDevices,
             minimumRSSI: optionalMax(self.minimumRSSI, minimumRSSI),
@@ -56,7 +57,8 @@ struct BluetoothManagerDiscoveryState: BluetoothScanningState {
 
 
 /// Intermediate storage object that is later translated to a BluetoothManagerDiscoveryState.
-struct BluetoothModuleDiscoveryState: BluetoothScanningState {
+@_spi(APISupport)
+public struct BluetoothModuleDiscoveryState: BluetoothScanningState {
     /// The minimum rssi that is required for a device to be considered discovered.
     let minimumRSSI: Int?
     /// The time interval after which an advertisement is considered stale and the device is removed.
@@ -71,7 +73,7 @@ struct BluetoothModuleDiscoveryState: BluetoothScanningState {
         self.autoConnect = autoConnect
     }
 
-    func merging(with other: BluetoothModuleDiscoveryState) -> BluetoothModuleDiscoveryState {
+    public func merging(with other: BluetoothModuleDiscoveryState) -> BluetoothModuleDiscoveryState {
         BluetoothModuleDiscoveryState(
             minimumRSSI: optionalMax(minimumRSSI, other.minimumRSSI),
             advertisementStaleInterval: optionalMax(advertisementStaleInterval, other.advertisementStaleInterval),
@@ -79,7 +81,7 @@ struct BluetoothModuleDiscoveryState: BluetoothScanningState {
         )
     }
 
-    func updateOptions(minimumRSSI: Int?, advertisementStaleInterval: TimeInterval?) -> BluetoothModuleDiscoveryState {
+    public func updateOptions(minimumRSSI: Int?, advertisementStaleInterval: TimeInterval?) -> BluetoothModuleDiscoveryState {
         BluetoothModuleDiscoveryState(
             minimumRSSI: optionalMax(self.minimumRSSI, minimumRSSI),
             advertisementStaleInterval: optionalMax(self.advertisementStaleInterval, advertisementStaleInterval),

--- a/Sources/SpeziBluetooth/Model/BluetoothService.swift
+++ b/Sources/SpeziBluetooth/Model/BluetoothService.swift
@@ -27,7 +27,28 @@
 ///     var firmwareRevision: String?
 /// }
 /// ```
+///
+/// ## Topics
+///
+/// ### Bluetooth UUID
+/// - ``id``
+///
+/// ### Configuration
+/// - ``configure()``
 public protocol BluetoothService {
     /// The Bluetooth service id.
     static var id: BTUUID { get }
+    
+    /// Configure the bluetooth service.
+    ///
+    /// Use this method to perform initial configuration of the service (e.g., set up `onChange` handlers).
+    /// This method is called by the ``Bluetooth`` module, once the device is getting configured.
+    @SpeziBluetooth
+    func configure()
+}
+
+
+extension BluetoothService {
+    /// Empty default configure method.
+    public func configure() {}
 }

--- a/Sources/SpeziBluetooth/Model/SemanticModel/SetupDeviceVisitor.swift
+++ b/Sources/SpeziBluetooth/Model/SemanticModel/SetupDeviceVisitor.swift
@@ -70,6 +70,9 @@ private struct SetupDeviceVisitor: DeviceVisitor {
             didInjectAnything: didInjectAnything
         )
         service.wrappedValue.accept(&visitor)
+
+        // call configure once the service is fully set up
+        service.wrappedValue.configure()
     }
 
     func visit<Action: _BluetoothPeripheralAction>(_ action: DeviceAction<Action>) {

--- a/Sources/SpeziBluetooth/Modifier/BluetoothScanner.swift
+++ b/Sources/SpeziBluetooth/Modifier/BluetoothScanner.swift
@@ -9,7 +9,8 @@
 import Foundation
 
 
-protocol BluetoothScanningState: Equatable, Sendable {
+@_spi(APISupport)
+public protocol BluetoothScanningState: Equatable, Sendable {
     /// Merge with another state. Order should not matter in the operation.
     /// - Parameter other: The other state to merge with
     func merging(with other: Self) -> Self
@@ -19,7 +20,8 @@ protocol BluetoothScanningState: Equatable, Sendable {
 
 
 /// Any kind of Bluetooth Scanner.
-protocol BluetoothScanner: Identifiable, Sendable where ID: Hashable {
+@_spi(APISupport)
+public protocol BluetoothScanner: Identifiable, Sendable where ID: Hashable {
     /// Captures state required to start scanning.
     associatedtype ScanningState: BluetoothScanningState
 

--- a/Sources/SpeziBluetooth/Modifier/ScanNearbyDevicesModifier.swift
+++ b/Sources/SpeziBluetooth/Modifier/ScanNearbyDevicesModifier.swift
@@ -109,7 +109,15 @@ private struct ScanNearbyDevicesModifier<Scanner: BluetoothScanner>: ViewModifie
 
 
 extension View {
-    func scanNearbyDevices<Scanner: BluetoothScanner>(enabled: Bool, scanner: Scanner, state: Scanner.ScanningState) -> some View {
+    /// Scan for nearby Bluetooth devices with a custom bluetooth scanner.
+    /// - Parameters:
+    ///   - enabled: Flag indicating if nearby device scanning is enabled.
+    ///   - scanner: The bluetooth scanner.
+    ///   - state: The current scanning state passed to the bluetooth scanner. ``BluetoothScanner/updateScanningState(_:)`` will be called if the contents of
+    ///     this parameter changes.
+    /// - Returns: The modified view.
+    @_spi(APISupport)
+    public func scanNearbyDevices<Scanner: BluetoothScanner>(enabled: Bool, scanner: Scanner, state: Scanner.ScanningState) -> some View {
         modifier(ScanNearbyDevicesModifier(enabled: enabled, scanner: scanner, state: state))
     }
 


### PR DESCRIPTION
# Support `configure()` call on services and expose BluetoothScanner via APISupport SPI

## :recycle: Current situation & Problem
Currently it is not possible for a `BluetoothService` implementation to provide steps for configuration (e.g., set up onChange handlers). Only the `BluetoothDevice` has a `configure()` method that can be used for these use cases. This PR adds a new `configure()` method to `BluetoothService`s such that their logic can be self-contained.
Additionally, the `scanNearbyDevices` has really useful logic for Bluetooth Scanners that was previously (< 2.0) accessible in the public interface, but is exclusively accessible to the `Bluetooth` module and the `BluetoothManager`. This PR exposes these interfaces as the `APISupport` SPI. This allows other library developers to reuse the `scanNearbyDevices` modifier for their custom Bluetooth scanner implementations (e.g., Muse SDK in NAMS).

## :gear: Release Notes 
* Added optional `configure()` method to the `BluetoothService` protocol to allow for self-container bluetooth service implementations.
* Allow to implement your own `BluetoothScanner`.


## :books: Documentation
Added documentation for newly exposed symbols.


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
