### PR TITLE
DeviceStateAccessor: fix incorrect `initial` parameter propagation; restore ability to connect to devices

### DIFF
--- a/Sources/SpeziBluetooth/Model/PropertySupport/DeviceStateAccessor.swift
+++ b/Sources/SpeziBluetooth/Model/PropertySupport/DeviceStateAccessor.swift
@@ -61,7 +61,7 @@ extension DeviceStateAccessor {
     ///     strictly if the value changes.
     ///     - action: The change handler to register.
     public func onChange(initial: Bool = false, perform action: @escaping @Sendable (Value) async -> Void) {
-        onChange(initial: true) { _, newValue in
+        onChange(initial: initial) { _, newValue in
             await action(newValue)
         }
     }


### PR DESCRIPTION
## :recycle: Current situation & Problem
Trying to connect (via SpeziDevices) to a peripheral doesn't work because the `nearby.onChange` state observer is sent an initial `false` value, which causes the peripheral to immediately get discarded after being discovered.


## :gear: Release Notes 
- Fix issue that could prevent peripheral connection establishment


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
