### PR TITLE
DeviceStateAccessor: fix incorrect `initial` parameter propagation; restore ability to connect to devices

### DIFF
--- a/Sources/SpeziBluetooth/Model/PropertySupport/DeviceStateAccessor.swift
+++ b/Sources/SpeziBluetooth/Model/PropertySupport/DeviceStateAccessor.swift
@@ -61,7 +61,7 @@ extension DeviceStateAccessor {
     ///     strictly if the value changes.
     ///     - action: The change handler to register.
     public func onChange(initial: Bool = false, perform action: @escaping @Sendable (Value) async -> Void) {
-        onChange(initial: true) { _, newValue in
+        onChange(initial: initial) { _, newValue in
             await action(newValue)
         }
     }

--- a/Sources/SpeziBluetooth/Modifier/AutoConnectModifier.swift
+++ b/Sources/SpeziBluetooth/Modifier/AutoConnectModifier.swift
@@ -29,8 +29,8 @@ extension View {
     ///     if we don't hear back from the device. Minimum is 1 second. Supply `nil` to use default the default value or a value from the environment.
     /// - Returns: The modified view.
     @MainActor
-    public func autoConnect( // swiftlint:disable:this function_default_parameter_at_end
-        enabled: Bool = true,
+    public func autoConnect(
+        enabled: Bool = true, // swiftlint:disable:this function_default_parameter_at_end
         with bluetooth: Bluetooth,
         minimumRSSI: Int? = nil,
         advertisementStaleInterval: TimeInterval? = nil
@@ -60,8 +60,8 @@ extension View {
     ///     if we don't hear back from the device. Minimum is 1 second. Supply `nil` to use default the default value or a value from the environment.
     /// - Returns: The modified view.
     @MainActor
-    public func autoConnect( // swiftlint:disable:this function_default_parameter_at_end
-        enabled: Bool = true,
+    public func autoConnect(
+        enabled: Bool = true, // swiftlint:disable:this function_default_parameter_at_end
         with bluetoothManager: BluetoothManager,
         discovery: Set<DiscoveryDescription>,
         minimumRSSI: Int? = nil,

--- a/Sources/SpeziBluetooth/Modifier/ScanNearbyDevicesModifier.swift
+++ b/Sources/SpeziBluetooth/Modifier/ScanNearbyDevicesModifier.swift
@@ -147,8 +147,8 @@ extension View {
     ///     if we don't hear back from the device. Minimum is 1 second. Supply `nil` to use default the default value or a value from the environment.
     ///   - autoConnect: If enabled, the bluetooth manager will automatically connect to the nearby device if only one is found.
     /// - Returns: The modified view.
-    public func scanNearbyDevices( // swiftlint:disable:this function_default_parameter_at_end
-        enabled: Bool = true,
+    public func scanNearbyDevices(
+        enabled: Bool = true, // swiftlint:disable:this function_default_parameter_at_end
         with bluetooth: Bluetooth,
         minimumRSSI: Int? = nil,
         advertisementStaleInterval: TimeInterval? = nil,
@@ -185,8 +185,8 @@ extension View {
     ///     if we don't hear back from the device. Minimum is 1 second. Supply `nil` to use default the default value or a value from the environment.
     ///   - autoConnect: If enabled, the bluetooth manager will automatically connect to the nearby device if only one is found.
     /// - Returns: The modified view.
-    public func scanNearbyDevices( // swiftlint:disable:this function_default_parameter_at_end
-        enabled: Bool = true,
+    public func scanNearbyDevices(
+        enabled: Bool = true, // swiftlint:disable:this function_default_parameter_at_end
         with bluetoothManager: BluetoothManager,
         discovery: Set<DiscoveryDescription>,
         minimumRSSI: Int? = nil,


### PR DESCRIPTION
## :recycle: Current situation & Problem
Trying to connect (via SpeziDevices) to a peripheral doesn't work because the `nearby.onChange` state observer is sent an initial `false` value, which causes the peripheral to immediately get discarded after being discovered.


## :gear: Release Notes 
- Fix issue that could prevent peripheral connection establishment


## :books: Documentation
n/a


## :white_check_mark: Testing
n/a


## :pencil: Code of Conduct & Contributing Guidelines 

By submitting creating this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).

---
Note: this PR supersedes #52 (the difference being that this one is made from an repo-internal branch, which @PSchmiedmayer said was required for some of the actions to properly run)