### PR TITLE
Fix compilation with Swift 6.1

### DIFF
--- a/Sources/SpeziBluetooth/Bluetooth.swift
+++ b/Sources/SpeziBluetooth/Bluetooth.swift
@@ -9,6 +9,7 @@
 import OrderedCollections
 import OSLog
 @_spi(APISupport)
+@_spi(Spezi)
 import Spezi
 
 
@@ -230,8 +231,7 @@ import Spezi
 /// ### Manually Manage Powered State
 /// - ``powerOn()``
 /// - ``powerOff()``
-@SpeziBluetooth
-public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
+public final class Bluetooth: Module, EnvironmentAccessible, @unchecked Sendable {
     @Observable
     class Storage {
         @MainActor var nearbyDevices: OrderedDictionary<UUID, any BluetoothDevice> = [:]
@@ -249,9 +249,9 @@ public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
     public nonisolated let configuration: Set<DeviceDiscoveryDescriptor>
 
     // sadly Swifts "lazy var" won't work here with strict concurrency as it doesn't isolate the underlying lazy storage
-    private var _lazy_discoveryConfiguration: Set<DiscoveryDescription>?
+    @SpeziBluetooth private var _lazy_discoveryConfiguration: Set<DiscoveryDescription>?
     // swiftlint:disable:previous discouraged_optional_collection identifier_name
-    private var discoveryConfiguration: Set<DiscoveryDescription> {
+    @SpeziBluetooth private var discoveryConfiguration: Set<DiscoveryDescription> {
         guard let discoveryConfiguration = _lazy_discoveryConfiguration else {
             let discovery = configuration.parseDiscoveryDescription()
             self._lazy_discoveryConfiguration = discovery
@@ -286,7 +286,7 @@ public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
     /// Subscribe to changes of the `state` property.
     ///
     /// Creates an `AsyncStream` that yields all **future** changes to the ``state`` property.
-    public var stateSubscription: AsyncStream<BluetoothState> {
+    public nonisolated var stateSubscription: AsyncStream<BluetoothState> {
         bluetoothManager.stateSubscription
     }
 
@@ -295,7 +295,7 @@ public final class Bluetooth: Module, EnvironmentAccessible, Sendable {
     /// Devices might be part of `nearbyDevices` as well or just retrieved devices that are eventually connected.
     /// Values are stored weakly. All properties (like `@Characteristic`, `@DeviceState` or `@DeviceAction`) store a reference to `Bluetooth` and report once they are de-initialized
     /// to clear the respective initialized devices from this dictionary.
-    private var initializedDevices: OrderedDictionary<UUID, AnyWeakDeviceReference> = [:]
+    @SpeziBluetooth private var initializedDevices: OrderedDictionary<UUID, AnyWeakDeviceReference> = [:]
 
     @Application(\.spezi)
     private var spezi

--- a/Sources/SpeziBluetooth/Utils/ConnectedDevicesModel.swift
+++ b/Sources/SpeziBluetooth/Utils/ConnectedDevicesModel.swift
@@ -11,13 +11,13 @@ import OrderedCollections
 
 
 @Observable
-class ConnectedDevicesModel {
+@MainActor
+class ConnectedDevicesModel: Sendable {
     /// We track the connected device for every BluetoothDevice type and index by peripheral identifier.
-    @MainActor private var connectedDevices: [ObjectIdentifier: OrderedDictionary<UUID, any BluetoothDevice>] = [:]
+    private var connectedDevices: [ObjectIdentifier: OrderedDictionary<UUID, any BluetoothDevice>] = [:]
 
-    init() {}
+    nonisolated init() {}
 
-    @MainActor
     func update(with devices: [UUID: any BluetoothDevice]) {
         // remove devices that disconnected
         for (identifier, var devicesById) in connectedDevices {
@@ -43,7 +43,6 @@ class ConnectedDevicesModel {
         }
     }
 
-    @MainActor
     subscript(_ identifier: ObjectIdentifier) -> [(any BluetoothDevice)] {
         guard let values = connectedDevices[identifier]?.values else {
             return []


### PR DESCRIPTION
# Fix compilation with Swift 6.1

## :recycle: Current situation & Problem
Swift 6.1 seems to cause some regressions that cause compiler errors again as reported previously in https://github.com/swiftlang/swift/issues/76005.
Presumably, again, it is caused by having the storage property for property wrappers under a different actor isolation than the "access property". We remove the global isolation and add a @unchcked Sendable for now to bypass Sendable warnings due to mutable storage of property wrappers.

## :gear: Release Notes
* Fix compilation under Swift 6.1


## :books: Documentation
--


## :white_check_mark: Testing
--


## :pencil: Code of Conduct & Contributing Guidelines
By creating and submitting this pull request, you agree to follow our [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md):
- [x] I agree to follow the [Code of Conduct](https://github.com/StanfordSpezi/.github/blob/main/CODE_OF_CONDUCT.md) and [Contributing Guidelines](https://github.com/StanfordSpezi/.github/blob/main/CONTRIBUTING.md).
